### PR TITLE
Adds behavior to be able pass object suggestions to Autosuggest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ function(input, callback) {
 `<suggestions>` can be have one of the following three formats:
 
 * **Single section with no title:** Array of strings, e.g.: `['Mentone', 'Mentone East']`
-* **Single section with no title:** Array of objects with `displayKey` for
+* **Single section with no title:** Array of objects with matching `displayKey` for
   rendering, e.g.:
 ```javascript
+<Autosuggest suggestions={getSuburbs}, displayKey={'name'} />
+
 [{
   name: "Mentone",
-  data: "Anything",
-  displayKey: "Mentone"
+  data: "Anything"
 }, {
   name: "Altona Meadows",
-  data: "More data",
-  displayKey: "Alt. Meadows"
+  data: "More data"
 }]
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,23 @@ function(input, callback) {
   * Success example: `callback(null, <suggestions>)` (see `<suggestions>` format below)
   * Error example: `callback(new Error("Couldn't get locations"))`
 
-`<suggestions>` can be have one of the following two formats:
+`<suggestions>` can be have one of the following three formats:
 
 * **Single section with no title:** Array of strings, e.g.: `['Mentone', 'Mentone East']`
+* **Single section with no title:** Array of objects with `displayKey` for
+  rendering, e.g.:
+```javascript
+[{
+  name: "Mentone",
+  data: "Anything",
+  displayKey: "Mentone"
+}, {
+  name: "Altona Meadows",
+  data: "More data",
+  displayKey: "Alt. Meadows"
+}]
+```
+
 * **One or more sections with optional titles:** Array of objects with an optional `sectionName` and a mandatory `suggestions` keys, e.g.:
 
 ```javascript

--- a/dist/Autosuggest.js
+++ b/dist/Autosuggest.js
@@ -50,7 +50,7 @@ var Autosuggest = React.createClass({
     }
   },
   isMultipleSections: function isMultipleSections(suggestions) {
-    return suggestions !== null && suggestions.length > 0 && typeof suggestions[0] === "object" && suggestions[0].suggestions != null;
+    return suggestions !== null && suggestions.length > 0 && typeof suggestions[0] === "object";
   },
   setSuggestionsState: function setSuggestionsState(suggestions) {
     this.multipleSections = this.isMultipleSections(suggestions);
@@ -228,10 +228,7 @@ var Autosuggest = React.createClass({
         "react-autosuggest__suggestion--focused": sectionIndex === this.state.focusedSectionIndex && suggestionIndex === this.state.focusedSuggestionIndex
       });
 
-      var suggestionContent = this.props.suggestionRenderer ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value) : typeof suggestion !== "object" ? suggestion : suggestion.displayKey != null ? suggestion.displayKey : null;
-      if (suggestionContent === null) {
-        throw new Error("Invalid suggestion");
-      }
+      var suggestionContent = this.props.suggestionRenderer ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value) : suggestion;
 
       return React.createElement(
         "div",

--- a/dist/Autosuggest.js
+++ b/dist/Autosuggest.js
@@ -50,7 +50,7 @@ var Autosuggest = React.createClass({
     }
   },
   isMultipleSections: function isMultipleSections(suggestions) {
-    return suggestions !== null && suggestions.length > 0 && typeof suggestions[0] === "object";
+    return suggestions !== null && suggestions.length > 0 && typeof suggestions[0] === "object" && suggestions[0].suggestions != null;
   },
   setSuggestionsState: function setSuggestionsState(suggestions) {
     this.multipleSections = this.isMultipleSections(suggestions);
@@ -228,7 +228,10 @@ var Autosuggest = React.createClass({
         "react-autosuggest__suggestion--focused": sectionIndex === this.state.focusedSectionIndex && suggestionIndex === this.state.focusedSuggestionIndex
       });
 
-      var suggestionContent = this.props.suggestionRenderer ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value) : suggestion;
+      var suggestionContent = this.props.suggestionRenderer ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value) : typeof suggestion !== "object" ? suggestion : suggestion.displayKey != null ? suggestion.displayKey : null;
+      if (suggestionContent === null) {
+        throw new Error("Invalid suggestion");
+      }
 
       return React.createElement(
         "div",

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -10,7 +10,8 @@ var Autosuggest = React.createClass({
   propTypes: {
     inputAttributes: PropTypes.objectOf(React.PropTypes.string), // Input's attributes (e.g. id, className)
     suggestions: PropTypes.func.isRequired,                      // Function to get the suggestions
-    suggestionRenderer: PropTypes.func                           // Function to render a single suggestion
+    suggestionRenderer: PropTypes.func,                          // Function to render a single suggestion
+    displayKey: PropTypes.string                                 // String that represents the key inside suggestion objects used to display the suggestion
   },
   getDefaultProps: function() {
     return {
@@ -191,7 +192,7 @@ var Autosuggest = React.createClass({
     });
   },
   onSuggestionMouseDown: function(suggestion) {
-    suggestion = typeof suggestion !== 'object' ? suggestion : suggestion['displayKey'];
+    suggestion = typeof suggestion !== 'object' ? suggestion : suggestion[this.props.displayKey];
     if(!suggestion) {
       throw new Error("Invalid suggestion");
     }
@@ -229,8 +230,8 @@ var Autosuggest = React.createClass({
         ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value)
         : typeof suggestion !== 'object'
         ? suggestion
-        : suggestion['displayKey'] != null
-        ? suggestion['displayKey']
+        : suggestion[this.props.displayKey] != null
+        ? suggestion[this.props.displayKey]
         : null;
         if(suggestionContent === null){
           throw new Error('Invalid suggestion');

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -223,7 +223,14 @@ var Autosuggest = React.createClass({
 
       var suggestionContent = this.props.suggestionRenderer
         ? this.props.suggestionRenderer(suggestion, this.state.valueBeforeUpDown || this.state.value)
-        : suggestion;
+        : typeof suggestion !== 'object'
+        ? suggestion
+        : suggestion['displayKey'] != null
+        ? suggestion['displayKey']
+        : null;
+        if(suggestionContent === null){
+          throw new Error('Invalid suggestion');
+        }
 
       return (
         <div id={this.getSuggestionId(sectionIndex, suggestionIndex)}

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -45,7 +45,8 @@ var Autosuggest = React.createClass({
   isMultipleSections: function(suggestions) {
     return suggestions !== null &&
            suggestions.length > 0 &&
-           typeof suggestions[0] === 'object';
+           typeof suggestions[0] === 'object' &&
+           suggestions[0]['suggestions'] != null;
   },
   setSuggestionsState: function(suggestions) {
     this.multipleSections = this.isMultipleSections(suggestions);

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -191,6 +191,10 @@ var Autosuggest = React.createClass({
     });
   },
   onSuggestionMouseDown: function(suggestion) {
+    suggestion = typeof suggestion !== 'object' ? suggestion : suggestion['displayKey'];
+    if(!suggestion) {
+      throw new Error("Invalid suggestion");
+    }
     this.setState({
       value: suggestion,
       suggestions: null,

--- a/src/tests/Autosuggest.js
+++ b/src/tests/Autosuggest.js
@@ -376,6 +376,30 @@ describe('Autosuggest', function() {
   });
 
   describe('Mouse interactions', function() {
+
+    describe('when suggestion is object', function() {
+
+      it('should set input field value when suggestion is clicked', function() {
+        createAutosuggest(
+          <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
+                       suggestions={getObjectSuggestions} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        setInputValue('m');
+        mouseDownSuggestion(1);
+        expectInputValue('sug2');
+      });
+
+      it('should throw error if suggestion object does not contain displayKey', function() {
+        createAutosuggest(
+          <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
+                       suggestions={getInvalidObjectSuggestions} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        expect(setInputValue.bind(null,'m')).toThrow('Invalid suggestion');
+      });
+    });
+
     beforeEach(function() {
       createAutosuggest(
         <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}

--- a/src/tests/Autosuggest.js
+++ b/src/tests/Autosuggest.js
@@ -35,26 +35,11 @@ function getObjectSuggestions(input, callback) {
   callback(null, [
     {
       name: "sug1",
-      data: 5,
-      displayKey: "sug1"
+      data: 5
     },
     {
       name: "sug2",
-      data: 4,
-      displayKey: "sug2"
-    },
-  ]);
-}
-
-function getInvalidObjectSuggestions(input, callback) {
-  callback(null, [
-    {
-      name: "sug1",
-      data: 5,
-    },
-    {
-      name: "sug2",
-      data: 4,
+      data: 4
     },
   ]);
 }
@@ -269,7 +254,8 @@ describe('Autosuggest', function() {
 
       it('should render suggestion as object\'s displayKey when suggestion is object ', function() {
         createAutosuggest(
-          <Autosuggest suggestions={getObjectSuggestions} />
+          <Autosuggest suggestions={getObjectSuggestions}
+                       displayKey={'name'} />
         );
         input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
         setInputValue('m');
@@ -282,11 +268,10 @@ describe('Autosuggest', function() {
 
       it('should throw error if suggestion is object and does not contain displayKey', function() {
         createAutosuggest(
-          <Autosuggest suggestions={getInvalidObjectSuggestions} />
+          <Autosuggest suggestions={getObjectSuggestions} />
         );
         input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
         expect(setInputValue.bind(null, 'm')).toThrow('Invalid suggestion');
-        // setInputValue('m');
       });
     });
   });
@@ -382,7 +367,8 @@ describe('Autosuggest', function() {
       it('should set input field value when suggestion is clicked', function() {
         createAutosuggest(
           <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
-                       suggestions={getObjectSuggestions} />
+                       suggestions={getObjectSuggestions}
+                       displayKey={'name'} />
         );
         input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
         setInputValue('m');
@@ -393,7 +379,7 @@ describe('Autosuggest', function() {
       it('should throw error if suggestion object does not contain displayKey', function() {
         createAutosuggest(
           <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
-                       suggestions={getInvalidObjectSuggestions} />
+                       suggestions={getObjectSuggestions} />
         );
         input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
         expect(setInputValue.bind(null,'m')).toThrow('Invalid suggestion');
@@ -526,7 +512,8 @@ describe('Autosuggest', function() {
 
     it('returns false if suggestions are regular objects', function() {
       createAutosuggest(
-        <Autosuggest suggestions={getObjectSuggestions} />
+        <Autosuggest suggestions={getObjectSuggestions}
+                     displayKey={'name'} />
       );
       input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
       setInputValue('m');

--- a/src/tests/Autosuggest.js
+++ b/src/tests/Autosuggest.js
@@ -31,6 +31,38 @@ function getMultipleSectionsSuburbs(input, callback) {
   }]);
 }
 
+function getObjectSuggestions(input, callback) {
+  callback(null, [
+    {
+      name: "sug1",
+      data: 5,
+      displayKey: "sug1"
+    },
+    {
+      name: "sug2",
+      data: 4,
+      displayKey: "sug2"
+    },
+  ]);
+}
+
+function getInvalidObjectSuggestions(input, callback) {
+  callback(null, [
+    {
+      name: "sug1",
+      data: 5,
+    },
+    {
+      name: "sug2",
+      data: 4,
+    },
+  ]);
+}
+
+function getMixedSuggestions(input, callback) {
+  callback(null, ["sug1", 2, "sug3"]);
+}
+
 function renderLocation(suggestion, input) {
   return (
     <span><strong>{suggestion.slice(0, input.length)}</strong>{suggestion.slice(input.length)}</span>
@@ -105,7 +137,7 @@ function expectFocusedSuggestion(suggestion) {
 
 function expectSections(expectedSections) {
   var sections = TestUtils.scryRenderedDOMComponentsWithClass(autosuggest, 'react-autosuggest__suggestions-section');
-  
+
   expect(sections.length).toBe(expectedSections.length);
 
   for (var i = 0; i < sections.length; i++) {
@@ -188,19 +220,74 @@ describe('Autosuggest', function() {
   });
 
   describe('Suggestion renderer', function() {
-    beforeEach(function() {
-      createAutosuggest(
-        <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
-                     suggestions={getSuburbs}
-                     suggestionRenderer={renderLocation} />
-      );
-      input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
-      setInputValue('m');
+
+    describe('when suggestionRenderer provided', function(){
+
+      it('should use the specified suggestionRenderer function', function() {
+        createAutosuggest(
+          <Autosuggest inputAttributes={{ id: 'my-autosuggest', value: 'my value' }}
+                       suggestions={getSuburbs}
+                       suggestionRenderer={renderLocation} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        setInputValue('m');
+
+        suggestions = TestUtils.scryRenderedDOMComponentsWithClass(autosuggest, 'react-autosuggest__suggestion');
+        expect(stripReactAttributes(suggestions[0].getDOMNode().innerHTML)).toBe('<span><strong>M</strong><span>ill Park</span></span>');
+      });
+
+      it('should pass regular objects to the suggestionRenderer function', function() {
+        var renderer = jest.genMockFunction();
+        createAutosuggest(
+          <Autosuggest suggestions={getObjectSuggestions}
+                       suggestionRenderer={renderer} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        setInputValue('m');
+
+        expect(renderer.mock.calls.length).toEqual(2);
+        expect(renderer.mock.calls[0][0]['name']).toEqual('sug1');
+        expect(renderer.mock.calls[1][0]['name']).toEqual('sug2');
+      });
     });
 
-    it('should use the specified suggestionRenderer function', function() {
-      suggestions = TestUtils.scryRenderedDOMComponentsWithClass(autosuggest, 'react-autosuggest__suggestion');
-      expect(stripReactAttributes(suggestions[0].getDOMNode().innerHTML)).toBe('<span><strong>M</strong><span>ill Park</span></span>');
+    describe('when suggestionRenderer not provided', function(){
+
+      it('should render suggestion as is if it is not an object, i.e. string or number', function() {
+        createAutosuggest(
+          <Autosuggest suggestions={getMixedSuggestions} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        setInputValue('m');
+
+        suggestions = TestUtils.scryRenderedDOMComponentsWithClass(autosuggest, 'react-autosuggest__suggestion');
+        expect(suggestions.length).toEqual(3);
+        expect(suggestions[0].props.children).toEqual('sug1');
+        expect(suggestions[1].props.children).toEqual(2);
+        expect(suggestions[2].props.children).toEqual('sug3');
+      });
+
+      it('should render suggestion as object\'s displayKey when suggestion is object ', function() {
+        createAutosuggest(
+          <Autosuggest suggestions={getObjectSuggestions} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        setInputValue('m');
+
+        suggestions = TestUtils.scryRenderedDOMComponentsWithClass(autosuggest, 'react-autosuggest__suggestion');
+        expect(suggestions.length).toEqual(2);
+        expect(suggestions[0].props.children).toEqual('sug1');
+        expect(suggestions[1].props.children).toEqual('sug2');
+      });
+
+      it('should throw error if suggestion is object and does not contain displayKey', function() {
+        createAutosuggest(
+          <Autosuggest suggestions={getInvalidObjectSuggestions} />
+        );
+        input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+        expect(setInputValue.bind(null, 'm')).toThrow('Invalid suggestion');
+        // setInputValue('m');
+      });
     });
   });
 
@@ -390,6 +477,36 @@ describe('Autosuggest', function() {
         suggestionsList = TestUtils.findRenderedDOMComponentWithClass(autosuggest, 'react-autosuggest__suggestions');
         expect(suggestionsList.getDOMNode().getAttribute('role')).toBe('listbox');
       });
+    });
+  });
+
+  describe('isMultipleSections', function(){
+
+    it('returns true if suggestions are multiple section objects', function() {
+      createAutosuggest(
+        <Autosuggest suggestions={getMultipleSectionsSuburbs} />
+      );
+      input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+      setInputValue('m');
+      expect(autosuggest.isMultipleSections(autosuggest.state.suggestions)).toBe(true);
+    });
+
+    it('returns false if suggestions are strings or numbers', function() {
+      createAutosuggest(
+        <Autosuggest suggestions={getMixedSuggestions} />
+      );
+      input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+      setInputValue('m');
+      expect(autosuggest.isMultipleSections(autosuggest.state.suggestions)).toBe(false);
+    });
+
+    it('returns false if suggestions are regular objects', function() {
+      createAutosuggest(
+        <Autosuggest suggestions={getObjectSuggestions} />
+      );
+      input = TestUtils.findRenderedDOMComponentWithTag(autosuggest, 'input').getDOMNode();
+      setInputValue('m');
+      expect(autosuggest.isMultipleSections(autosuggest.state.suggestions)).toBe(false);
     });
   });
 


### PR DESCRIPTION
- Opposite to only being able to pass suggestions as strings or numbers, or multi sections objects
- If no suggestionRenderer function is passed, it will attempt to render displayKey of suggestion object if suggestion is an object