### PR TITLE
Allow external access to input onchange events

### DIFF
--- a/examples/src/BasicExample/BasicExample.js
+++ b/examples/src/BasicExample/BasicExample.js
@@ -26,6 +26,10 @@ function getSuggestions(input, callback) {
 }
 
 export default class BasicExample extends Component {
+  handleInputChange(e) {
+    console.log(e.target.value);
+  }
+
   render() {
     let inputAttributes = {
       id: 'basic-example',
@@ -36,6 +40,7 @@ export default class BasicExample extends Component {
       <div>
         <Autosuggest suggestions={getSuggestions}
                      inputAttributes={inputAttributes}
+                     onInputChange={this.handleInputChange}
                      ref={ () => { document.getElementById('basic-example').focus(); } } />
         <SourceCodeLink file="examples/src/BasicExample/BasicExample.js" />
       </div>

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -14,6 +14,9 @@ export default class Autosuggest extends Component {
     suggestionValue: PropTypes.func,                      // Function that maps suggestion object to input value (must be implemented when suggestions are objects)
     showWhen: PropTypes.func,                             // Function that determines whether to show suggestions or not
     onSuggestionSelected: PropTypes.func,                 // This function is called when suggestion is selected via mouse click or Enter
+
+    onInputChange: PropTypes.func,                        // Function to allow external access to input onChange events
+
     inputAttributes: PropTypes.objectOf(PropTypes.string) // Attributes to pass to the input field (e.g. { id: 'my-input', className: 'sweet autosuggest' })
   }
 
@@ -149,6 +152,10 @@ export default class Autosuggest extends Component {
       value: newValue,
       valueBeforeUpDown: null
     });
+
+    if (this.props.onInputChange) {
+      this.props.onInputChange(event);
+    }
 
     this.showSuggestions(newValue);
   }


### PR DESCRIPTION
Currently the AutoSuggest component wraps an input element, but
doesn't allow access to the onChange event.

This event is useful in situations where the user types some text that isn't
one of the suggested values but still needs to be captured by parent
component.