### PR TITLE
Allow to set a custom guid to the component

### DIFF
--- a/dist/Autosuggest.js
+++ b/dist/Autosuggest.js
@@ -46,8 +46,13 @@ var Autosuggest = (function (_Component) {
 
     _get(Object.getPrototypeOf(Autosuggest.prototype), 'constructor', this).call(this);
 
-    guid += 1;
-    this.id = guid;
+    if (props.inputAttributes.id) {
+       this.id = props.inputAttributes.id;
+     } else {
+       guid += 1;
+       this.id = guid;
+     }
+    
     this.cache = {};
     this.state = {
       value: props.inputAttributes.value || '',

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -30,8 +30,13 @@ export default class Autosuggest extends Component {
   constructor(props) {
     super();
 
-    guid += 1;
-    this.id = guid;
+    if (props.inputAttributes.id) {
+      this.id = props.inputAttributes.id;
+    } else {
+      guid += 1;
+      this.id = guid;
+    }
+
     this.cache = {};
     this.state = {
       value: props.inputAttributes.value || '',


### PR DESCRIPTION
In a normal case, your component works fine, but in an isomorphic app, react display a warning because the server and client guid are different. You set a different guid (by incrementing it) for each component creation. In an isomorphic app, we need to have all of ours components equals. Without it, we are loosing the react benefit and the page will be re render totally. So we need to override it when it's necessary.