### PR TITLE
Move react to peerDependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "classnames": "^2.1.1",
-    "debounce": "^1.0.0",
+    "debounce": "^1.0.0"
+  },
+  "peerDependencies": {
     "react": "^0.13.3"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "less-loader": "^2.2.0",
     "mocha": "^2.2.5",
     "proxyquire": "^1.5.0",
+    "react": "^0.13.3",
     "react-a11y": "^0.1.1",
     "react-hot-loader": "^1.2.7",
     "sinon": "^1.14.1",


### PR DESCRIPTION
Otherwise multiple versions of React can be loaded which causes weird bugs such as
`Uncaught Error: Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. This usually means that you're trying to add a ref to a component that doesn't have an owner (that is, was not created inside of another component's `render` method). Try rendering this component inside of a new top-level component which will hold the ref.`

See also https://github.com/JedWatson/react-select/issues/88 https://github.com/yahoo/flux-router-component/issues/33