### PR TITLE
Support for controlled components via value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@
 * Full control over [styling](#styling) (we just provide the mechanics and classes for you)
 * Full control over [when to show the suggestions](#showWhenOption) (e.g. when user types 2 or more characters)
 * Various hooks: [onSuggestionSelected](#onSuggestionSelectedOption), [onSuggestionFocused](#onSuggestionFocusedOption), [onSuggestionUnfocused](#onSuggestionUnfocusedOption)
-* Ability to [pass props to the input field](#inputAttributesOption) (e.g. initial value, placeholder, onChange, onBlur)
+* Support for [controlled](https://facebook.github.io/react/docs/forms.html#controlled-components) as well as [uncontrolled](https://facebook.github.io/react/docs/forms.html#uncontrolled-components) state
+* Ability to [pass props to the input field](#inputAttributesOption) (e.g. placeholder, onChange, onBlur)
 * In-memory caching (we retrieve suggestions for a given input only once)
 * Thoroughly tested (over 100 tests)
 
@@ -61,6 +62,8 @@ Check out the [standalone example](https://github.com/moroshko/react-autosuggest
 * [`suggestions`](#suggestionsOption)
 * [`suggestionRenderer`](#suggestionRendererOption)
 * [`suggestionValue`](#suggestionValueOption)
+* [`defaultValue`](#defaultValueOption)
+* [`value`](#valueOption)
 * [`showWhen`](#showWhenOption)
 * [`onSuggestionSelected`](#onSuggestionSelectedOption)
 * [`onSuggestionFocused`](#onSuggestionFocusedOption)
@@ -153,6 +156,52 @@ function getSuggestionValue(suggestionObj) {
              suggestionRenderer={renderSuggestion}
              suggestionValue={getSuggestionValue} />
 ```
+
+<a name="defaultValueOption"></a>
+#### defaultValue (optional)
+
+This string sets the initial value of the text. The default is an empty string.
+
+Set this value if you want to use the component in an [uncontrolled](https://facebook.github.io/react/docs/forms.html#uncontrolled-components) manner (the component keeps track of its state internally).
+
+For example:
+
+```xml
+<Autosuggest suggestions={getSuggestions}
+             defaultValue="Mordialloc" />
+```
+
+Note: if you specify this option then you should not include a [`value`](#valueOption).
+
+<a name="valueOption"></a>
+#### value (optional)
+
+This string determines the value of the currently-selected suggestion.
+
+Set this value if you want to use the component in a [controlled](https://facebook.github.io/react/docs/forms.html#controlled-components) manner (the component uses an outside source of state). The currently-selected suggestion text will update whenever this option is updated, so it is recommended that you use a combination of `value` and [`onSuggestionSelected`](#onSuggestionSelectedOption) to keep track of the selected state inside a parent component.
+
+For example:
+
+```js
+// Inside a React component...
+function getInitialState() {
+  return { activeSuggestion: 'one' };
+}
+function getActiveSuggestion() {
+  return this.state.activeSuggestion;
+}
+function setActiveSuggestion(suggestion) {
+  this.setState({ activeSuggestion: suggestion });
+}
+```
+
+```xml
+<Autosuggest suggestions={getSuggestions}
+             value={getActiveSuggestion()}
+             onSuggestionSelected={setActiveSuggestion} />
+```
+
+Note: if you specify this option then you should not include a [defaultValue](#defaultValueOption).
 
 <a name="showWhenOption"></a>
 #### showWhen (optional)
@@ -263,7 +312,6 @@ const inputAttributes = {
   name: 'locations-autosuggest',
   className: 'my-sweet-locations-autosuggest',
   placeholder: 'Enter locations...',
-  value: 'Mordialloc',   // Initial value
   onChange: value => console.log(`Input value changed to: ${value}`),
   onBlur: () => console.log('Input blurred')
 };

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,7 @@
+Upgrade Guide
+=============
+
+### 1.xx.xx -> 2.xx.xx
+
+- **Breaking:** `inputAttributes.value` is no longer supported. Instead, use the top-level property `defaultValue` to mimic the same ([uncontrolled](https://facebook.github.io/react/docs/forms.html#uncontrolled-components)) behavior.
+  - Or, if you want to use the component in a [controlled](https://facebook.github.io/react/docs/forms.html#controlled-components) way, use the top-level `value` property.

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -7,6 +7,8 @@ import sectionIterator from './sectionIterator';
 
 export default class Autosuggest extends Component { // eslint-disable-line no-shadow
   static propTypes = {
+    value: PropTypes.string,                // Controlled value of the selected suggestion
+    defaultValue: PropTypes.string,         // Initial value of the text
     suggestions: PropTypes.func.isRequired, // Function to get the suggestions
     suggestionRenderer: PropTypes.func,     // Function that renders a given suggestion (must be implemented when suggestions are objects)
     suggestionValue: PropTypes.func,        // Function that maps suggestion object to input value (must be implemented when suggestions are objects)
@@ -16,6 +18,13 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     onSuggestionUnfocused: PropTypes.func,  // This function is called when suggestion is unfocused via mouse hover or Up/Down keys
     inputAttributes: PropTypes.object,      // Attributes to pass to the input field (e.g. { id: 'my-input', className: 'sweet autosuggest' })
     id: PropTypes.string                    // Used in aria-* attributes. If multiple Autosuggest's are rendered on a page, they must have unique ids.
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value) {
+      // If this component is controlled, then handle the value update
+      this.handleValueChange(nextProps.value);
+    }
   }
 
   static defaultProps = {
@@ -32,7 +41,7 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
 
     this.cache = {};
     this.state = {
-      value: props.inputAttributes.value || '',
+      value: props.value || props.defaultValue || '',
       suggestions: null,
       focusedSectionIndex: null,    // Used when multiple sections are displayed
       focusedSuggestionIndex: null, // Index within a section
@@ -212,7 +221,11 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
 
   onInputChange(event) {
     const newValue = event.target.value;
+    this.handleValueChange(newValue);
+    this.showSuggestions(newValue);
+  }
 
+  handleValueChange(newValue) {
     this.onSuggestionUnfocused();
     this.onChange(newValue);
 
@@ -220,8 +233,6 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
       value: newValue,
       valueBeforeUpDown: null
     });
-
-    this.showSuggestions(newValue);
   }
 
   onInputKeyDown(event) {

--- a/src/tests/Autosuggest.js
+++ b/src/tests/Autosuggest.js
@@ -244,11 +244,11 @@ describe('Autosuggest', () => {
       beforeEach(() => {
         createAutosuggest(
           <Autosuggest suggestions={getSuburbStrings}
+                       defaultValue="my value"
                        inputAttributes={{ id: 'my-autosuggest',
                                           name: 'my-autosuggest-name',
                                           placeholder: 'Enter location...',
-                                          className: 'my-sweet-autosuggest',
-                                          value: 'my value' }} />
+                                          className: 'my-sweet-autosuggest' }} />
         );
       });
 
@@ -314,6 +314,68 @@ describe('Autosuggest', () => {
         setInputValue('m');
         expectSuggestions(['Mill Park VIC 3083', 'Mordialloc VIC 3195']);
       });
+    });
+  });
+
+  describe('(controlled behavior)', () => {
+    beforeEach(() => {
+      const parent = React.createElement(React.createClass({
+        getInitialState() {
+          return { location: 'Mill Park' };
+        },
+        getLocation() {
+          return this.state.location;
+        },
+        setLocation(location) {
+          this.setState({ location });
+        },
+        render() {
+          return (
+            <div>
+              <Autosuggest suggestions={getSuburbStrings}
+                value={this.getLocation()}
+                onSuggestionSelected={this.setLocation}
+                inputAttributes={{ id: 'my-autosuggest',
+                                   name: 'my-autosuggest-name',
+                                   placeholder: 'Enter location...',
+                                   className: 'my-sweet-autosuggest' }} />
+              <div className="result">{ this.getLocation() }</div>
+            </div>
+          );
+        }
+      }));
+      createAutosuggest(parent);
+    });
+
+    it('should set initial value', () => {
+      expectInputValue('Mill Park');
+    });
+
+    it('should not show suggestions by default', () => {
+      expectSuggestions([]);
+    });
+
+    it('should show suggestions when matches exist', () => {
+      setInputValue('m');
+      expectSuggestions(['Mill Park', 'Mordialloc']);
+    });
+
+    it('should show not suggestions when no matches exist', () => {
+      setInputValue('a');
+      expectSuggestions([]);
+    });
+
+    it('should only update when the outside value changes', () => {
+      setInputValue('m');
+      mouseOverFromInputToSuggestion(1);
+      mouseDownSuggestion(1);
+      expectSuggestions([]);
+      expectInputValue('Mordialloc');
+      let val = React.findDOMNode(TestUtils.findRenderedDOMComponentWithClass(autosuggest, 'result')).innerHTML;
+      expect(val).to.equal('Mordialloc');
+      setInputValue('some other invalid value');
+      val = React.findDOMNode(TestUtils.findRenderedDOMComponentWithClass(autosuggest, 'result')).innerHTML;
+      expect(val).to.equal('Mordialloc');
     });
   });
 


### PR DESCRIPTION
This is a breaking change: "value" is no longer a part of inputAttributes and instead is now a top-level property. To support uncontroleld behavior, a new "defaultValue" prop was added.

Fixes #28 
@moroshko 