### PR TITLE
Support CSS Modules and inline styles for theming

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "gh-pages": "git checkout gh-pages; git pull; git merge master --no-edit; npm run examples-dist; cp examples/dist/*.* .; git add index.html app.css app.js; git commit -m 'Update gh-pages files'; git push; git checkout master"
   },
   "dependencies": {
-    "classnames": "^2.1.3",
-    "debounce": "^1.0.0"
+    "debounce": "^1.0.0",
+    "react-themeable": "^1.0.1"
   },
   "peerDependencies": {
     "react": "^0.13.3"

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes, findDOMNode } from 'react';
 import debounce from 'debounce';
-import classnames from 'classnames';
+import themeable from 'react-themeable';
 import sectionIterator from './sectionIterator';
 
 export default class Autosuggest extends Component { // eslint-disable-line no-shadow
@@ -15,7 +15,8 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     inputAttributes: PropTypes.object,      // Attributes to pass to the input field (e.g. { id: 'my-input', className: 'sweet autosuggest' })
     cache: PropTypes.bool,                  // Set it to false to disable in-memory caching
     id: PropTypes.string,                   // Used in aria-* attributes. If multiple Autosuggest's are rendered on a page, they must have unique ids.
-    scrollBar: PropTypes.bool               // Set it to true when the suggestions container can have a scroll bar
+    scrollBar: PropTypes.bool,              // Set it to true when the suggestions container can have a scroll bar
+    theme: PropTypes.object                 // Custom theme (CSS Module or inline styles definition)
   }
 
   static defaultProps = {
@@ -26,7 +27,16 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     inputAttributes: {},
     cache: true,
     id: '1',
-    scrollBar: false
+    scrollBar: false,
+    theme: {
+      'root': 'react-autosuggest',
+      'suggestions': 'react-autosuggest__suggestions',
+      'suggestion': 'react-autosuggest__suggestion',
+      'suggestion_isFocused': 'react-autosuggest__suggestion--focused',
+      'section': 'react-autosuggest__suggestions-section',
+      'sectionName': 'react-autosuggest__suggestions-section-name',
+      'sectionSuggestions': 'react-autosuggest__suggestions-section-suggestions'
+    }
   }
 
   constructor(props) {
@@ -441,20 +451,22 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     }
   }
 
-  renderSuggestionsList(suggestions, sectionIndex) {
+  renderSuggestionsList(theme, suggestions, sectionIndex) {
     return suggestions.map((suggestion, suggestionIndex) => {
-      const classes = classnames({
-        'react-autosuggest__suggestion': true,
-        'react-autosuggest__suggestion--focused':
+      const styles = theme(suggestionIndex,
+        'suggestion',
+        (
           sectionIndex === this.state.focusedSectionIndex &&
-          suggestionIndex === this.state.focusedSuggestionIndex
-      });
+          suggestionIndex === this.state.focusedSuggestionIndex &&
+          'suggestion_isFocused'
+        )
+      );
       const suggestionRef =
         this.getSuggestionRef(sectionIndex, suggestionIndex);
 
       return (
         <li id={this.getSuggestionId(sectionIndex, suggestionIndex)}
-            className={classes}
+            { ...styles }
             role="option"
             ref={suggestionRef}
             key={suggestionRef}
@@ -467,7 +479,7 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     });
   }
 
-  renderSuggestions() {
+  renderSuggestions(theme) {
     if (this.state.suggestions === null) {
       return null;
     }
@@ -475,22 +487,22 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
     if (this.isMultipleSections(this.state.suggestions)) {
       return (
         <div id={'react-autosuggest-' + this.props.id}
-             className="react-autosuggest__suggestions"
+             { ...theme('suggestions', 'suggestions') }
              ref="suggestions"
              role="listbox">
           {this.state.suggestions.map((section, sectionIndex) => {
             const sectionName = section.sectionName ? (
-              <div className="react-autosuggest__suggestions-section-name">
+              <div { ...theme('sectionName-' + sectionIndex, 'sectionName') }>
                 {section.sectionName}
               </div>
             ) : null;
 
             return section.suggestions.length === 0 ? null : (
-              <div className="react-autosuggest__suggestions-section"
+              <div { ...theme('section-' + sectionIndex, 'section') }
                    key={'section-' + sectionIndex}>
                 {sectionName}
-                <ul className="react-autosuggest__suggestions-section-suggestions">
-                  {this.renderSuggestionsList(section.suggestions, sectionIndex)}
+                <ul { ...theme('sectionSuggestions-' + sectionIndex, 'sectionSuggestions') }>
+                  {this.renderSuggestionsList(theme, section.suggestions, sectionIndex)}
                 </ul>
               </div>
             );
@@ -501,20 +513,22 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
 
     return (
       <ul id={'react-autosuggest-' + this.props.id}
-          className="react-autosuggest__suggestions"
+          { ...theme('suggestions', 'suggestions') }
           ref="suggestions"
           role="listbox">
-        {this.renderSuggestionsList(this.state.suggestions, null)}
+        {this.renderSuggestionsList(theme, this.state.suggestions, null)}
       </ul>
     );
   }
 
   render() {
+    const theme = themeable(this.props.theme);
+
     const ariaActivedescendant =
       this.getSuggestionId(this.state.focusedSectionIndex, this.state.focusedSuggestionIndex);
 
     return (
-      <div className="react-autosuggest">
+      <div { ...theme('root', 'root') }>
         <input {...this.props.inputAttributes}
                type={this.props.inputAttributes.type || 'text'}
                value={this.state.value}
@@ -529,7 +543,7 @@ export default class Autosuggest extends Component { // eslint-disable-line no-s
                onKeyDown={this.onInputKeyDown}
                onFocus={this.onInputFocus}
                onBlur={this.onInputBlur} />
-        {this.renderSuggestions()}
+        {this.renderSuggestions(theme)}
       </div>
     );
   }


### PR DESCRIPTION
This allows themes to be provided following the [react-themeable](https://github.com/markdalgleish/react-themeable) standard.

The default theme values match the existing global classes defined in your readme, so this maintains support for those still using global CSS. Of course, these values now form part of your component's public API, so you may want to rename them.

This code in this PR is undocumented. I attempted to update the readme but it turned out to be a much larger change than I anticipated, so I figured it's best left up to you. I'm happy to help, of course.