### PR TITLE
Add 0.14.0-beta3 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debounce": "^1.0.0"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.13.3 || ^0.14.0-beta3"
   },
   "devDependencies": {
     "babel": "^5.6.23",


### PR DESCRIPTION
This is necessary to use the package with the current beta release of React.