### PR TITLE
add focusAfterSuggestionSelected optional prop, default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Check out the [standalone example](https://github.com/moroshko/react-autosuggest
 * [`id`](#idOption)
 * [`scrollBar`](#scrollBarOption)
 * [`theme`](#themeOption)
+* [`focusAfterSuggestionSelected`](#focusAfterSuggestionSelected)
 
 <a name="suggestionsOption"></a>
 #### suggestions (required)
@@ -451,6 +452,15 @@ The following diagrams explain the classes above.
     |  +----------------------------------------------------------------------+  |
     |                                                                            |
     +----------------------------------------------------------------------------+
+
+<a name="focusAfterSuggestionSelectedOption"></a>
+#### focusAfterSuggestionSelected (optional)
+
+Defaults to `true`
+
+Input will receive focus after a suggestion is selected
+
+Set `focusAfterSuggestionSelected={false}` to disable this behaviour.
 
 ## Development
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -19,7 +19,8 @@ export default class Autosuggest extends Component {
     cache: PropTypes.bool,                  // Set it to false to disable in-memory caching
     id: PropTypes.string,                   // Used in aria-* attributes. If multiple Autosuggest's are rendered on a page, they must have unique ids.
     scrollBar: PropTypes.bool,              // Set it to true when the suggestions container can have a scroll bar
-    theme: PropTypes.object                 // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    theme: PropTypes.object,                // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    focusAfterSuggestionSelected: PropTypes.bool  // Set it to false to prevent input focus after selection
   }
 
   static defaultProps = {
@@ -31,6 +32,7 @@ export default class Autosuggest extends Component {
     cache: true,
     id: '1',
     scrollBar: false,
+    focusAfterSuggestionSelected: true,
     theme: {
       root: 'react-autosuggest',
       suggestions: 'react-autosuggest__suggestions',
@@ -443,7 +445,9 @@ export default class Autosuggest extends Component {
     }, () => {
       // This code executes after the component is re-rendered
       setTimeout(() => {
-        findDOMNode(this.refs.input).focus();
+        if( this.props.focusAfterSuggestionSelected ){
+          findDOMNode(this.refs.input).focus();
+        }
         this.justClickedOnSuggestion = false;
       });
     });


### PR DESCRIPTION
I'm running into a problem on mobile devices where I want to blur the input after a selection, mainly so that the device's on screen keyboard will hide after an option is picked. 

If I blur in the `onSuggestionSelected` event callback handler, the `findDOMNode(this.refs.input).focus();` in `onSuggestionMouseDown` ends up focusing the input again. 

Right now I've resorted to using a timeout in `onSuggestionSelected` to blur the input. I'd prefer a simple option to control the behavior. 