### PR TITLE
ISSUE #73 Use touchTap event instead of touchstart.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "debounce": "^1.0.0",
+    "react-tap-event-plugin": "^0.2.1",
     "react-themeable": "^1.0.1"
   },
   "peerDependencies": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -3,6 +3,8 @@ import { findDOMNode } from 'react-dom';
 import debounce from 'debounce';
 import themeable from 'react-themeable';
 import sectionIterator from './sectionIterator';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+injectTapEventPlugin();
 
 export default class Autosuggest extends Component {
   static propTypes = {
@@ -511,7 +513,7 @@ export default class Autosuggest extends Component {
             onMouseEnter={() => this.onSuggestionMouseEnter(sectionIndex, suggestionIndex)}
             onMouseLeave={() => this.onSuggestionMouseLeave(sectionIndex, suggestionIndex)}
             onMouseDown={onSuggestionClick}
-            onTouchStart={onSuggestionClick}>
+            onTouchTap={onSuggestionClick}>
           {this.renderSuggestionContent(suggestion)}
         </li>
       );


### PR DESCRIPTION
So we need a tapEvent since react doesnt support it (yet). It's possible to do a custom solution that saves touchStarts position and a timestamp. Then onTouchEnd compare that position and check how long time that has passed. This way we can ignore scrolling and "long touches".

A faster and more clean solution is the [react-tap-event-plugin] (https://github.com/zilverline/react-tap-event-plugin/blob/master/README.md). It hooks into reacts event system and adds a touchTap event.
Then when react adds touchTap event its easy to remove this dependency.

From react-tap-event-plugin:
You've probably heard of [iOS's dreaded 300ms tap delay](http://updates.html5rocks.com/2013/12/300ms-tap-delay-gone-away).  React's `onClick` attribute falls prey to it.  Facebook's working on a solution in the form of `TapEventPlugin`, but it [won't be made available](https://github.com/facebook/react/issues/436) [until 1.0](https://github.com/facebook/react/pull/1170).

If you're reading this, you're probably working on a project that can't wait until they figure out how they want to publish it.  This repo is for you.

When Facebook solves [#436](https://github.com/facebook/react/issues/436) and [#1170](https://github.com/facebook/react/pull/1170), this repo will disappear.
