### PR TITLE
Added debounce prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Check out the [standalone example](https://github.com/moroshko/react-autosuggest
 * [`id`](#idOption)
 * [`scrollBar`](#scrollBarOption)
 * [`theme`](#themeOption)
+* [`debounce`](#debounce)
 
 <a name="suggestionsOption"></a>
 #### suggestions (required)
@@ -452,6 +453,14 @@ The following diagrams explain the classes above.
     |  +----------------------------------------------------------------------+  |
     |                                                                            |
     +----------------------------------------------------------------------------+
+
+<a name="debounce"></a>
+#### debounce (optional)
+
+Specifies the number of milliseconds to wait before invoking the `getSuggestions` function. The default value is 100.  
+Usefull for reducing the amount of calls to the server.  
+
+For example a value of 0 would fetch new suggestions in realtime, whenever the user changes the input value. A value of 1000 on the other hand would fetch the suggestions only after the user didn't type anything for one second.
 
 ## Development
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -22,7 +22,8 @@ export default class Autosuggest extends Component {
     cache: PropTypes.bool,                  // Set it to false to disable in-memory caching
     id: PropTypes.string,                   // Used in aria-* attributes. If multiple Autosuggest's are rendered on a page, they must have unique ids.
     scrollBar: PropTypes.bool,              // Set it to true when the suggestions container can have a scroll bar
-    theme: PropTypes.object                 // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    theme: PropTypes.object,                // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    debounce: PropTypes.number              // Amount of miliseconds to wait before calling getSuggestions after the last user input
   }
 
   static defaultProps = {
@@ -42,7 +43,8 @@ export default class Autosuggest extends Component {
       section: 'react-autosuggest__suggestions-section',
       sectionName: 'react-autosuggest__suggestions-section-name',
       sectionSuggestions: 'react-autosuggest__suggestions-section-suggestions'
-    }
+    },
+    debounce: 100
   }
 
   constructor(props) {
@@ -60,7 +62,7 @@ export default class Autosuggest extends Component {
                                     // See: http://www.w3.org/TR/wai-aria-practices/#autocomplete
     };
     this.isControlledComponent = (typeof props.value !== 'undefined');
-    this.suggestionsFn = debounce(props.suggestions, 100);
+    this.suggestionsFn = debounce(props.suggestions, props.suggestions, props.debounce);
     this.onChange = props.inputAttributes.onChange || (() => {});
     this.onFocus = props.inputAttributes.onFocus || (() => {});
     this.onBlur = props.inputAttributes.onBlur || (() => {});

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -92,6 +92,9 @@ export default class Autosuggest extends Component {
         this.handleValueChange(nextProps.value);
       }
     }
+    if (nextProps.debounce !== this.props.debounce) {
+      this.suggestionsFn = debounce(this.props.suggestions, nextProps.debounce);
+    }
   }
 
   resetSectionIterator(suggestions) {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -62,7 +62,7 @@ export default class Autosuggest extends Component {
                                     // See: http://www.w3.org/TR/wai-aria-practices/#autocomplete
     };
     this.isControlledComponent = (typeof props.value !== 'undefined');
-    this.suggestionsFn = debounce(props.suggestions, props.suggestions, props.debounce);
+    this.updateSuggestionsFn(props);
     this.onChange = props.inputAttributes.onChange || (() => {});
     this.onFocus = props.inputAttributes.onFocus || (() => {});
     this.onBlur = props.inputAttributes.onBlur || (() => {});
@@ -92,9 +92,15 @@ export default class Autosuggest extends Component {
         this.handleValueChange(nextProps.value);
       }
     }
-    if (nextProps.debounce !== this.props.debounce) {
-      this.suggestionsFn = debounce(this.props.suggestions, nextProps.debounce);
+    if (nextProps.debounce !== this.props.debounce || nextProps.suggestions !== this.props.suggestions) {
+      this.updateSuggestionsFn(nextProps);
     }
+  }
+
+  updateSuggestionsFn = (nextProps) => {
+    const fn = nextProps.suggestions || this.props.suggestions;
+    const delay = nextProps.debounce || this.props.debounce;
+    this.suggestionsFn = debounce(fn, delay);
   }
 
   resetSectionIterator(suggestions) {


### PR DESCRIPTION
Allows custom debounce delays for fetching and showing suggestions. The default value of 100ms is still used, however, the component now accepts the optional 'debounce' prop / attribute.

Added short explanation in the readme file.
Did not add separate example.