### PR TITLE
Satisfy react-dom by react.js in standalone config

### DIFF
--- a/webpack.standalone.config.js
+++ b/webpack.standalone.config.js
@@ -21,7 +21,8 @@ module.exports = [{
   },
 
   externals: {
-    react: 'React'
+    'react': 'React',
+    'react-dom': 'React'
   }
 }, {
   entry: './src/Autosuggest.js',
@@ -43,7 +44,8 @@ module.exports = [{
   },
 
   externals: {
-    react: 'React'
+    'react': 'React',
+    'react-dom': 'React'
   },
 
   plugins: [


### PR DESCRIPTION
Right now, the webpack standalone config unnessecarily includes react-dom, which bloats unminified size to 640K. With this change, react-dom is satisfied by `window.React`, which shrinks unminified size down to ~105K.