### PR TITLE
Reset callback fns when props are updated

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -60,10 +60,7 @@ export default class Autosuggest extends Component {
                                     // See: http://www.w3.org/TR/wai-aria-practices/#autocomplete
     };
     this.isControlledComponent = (typeof props.value !== 'undefined');
-    this.suggestionsFn = debounce(props.suggestions, 100);
-    this.onChange = props.inputAttributes.onChange || (() => {});
-    this.onFocus = props.inputAttributes.onFocus || (() => {});
-    this.onBlur = props.inputAttributes.onBlur || (() => {});
+    this.updateProps(props);
     this.lastSuggestionsInputValue = null; // Helps to deal with delayed requests
     this.justUnfocused = false; // Helps to avoid calling onSuggestionUnfocused
                                 // twice when mouse is moving between suggestions
@@ -81,6 +78,13 @@ export default class Autosuggest extends Component {
     this.onInputBlur = ::this.onInputBlur;
   }
 
+  updateProps(nextProps) {
+    this.suggestionsFn = debounce(nextProps.suggestions, 100);
+    this.onChange = nextProps.inputAttributes.onChange || (() => {});
+    this.onFocus = nextProps.inputAttributes.onFocus || (() => {});
+    this.onBlur = nextProps.inputAttributes.onBlur || (() => {});
+  }
+
   componentWillReceiveProps(nextProps) {
     if (this.isControlledComponent) {
       const inputValue = findDOMNode(this.refs.input).value;
@@ -90,6 +94,7 @@ export default class Autosuggest extends Component {
         this.handleValueChange(nextProps.value);
       }
     }
+    this.updateProps(nextProps);
   }
 
   resetSectionIterator(suggestions) {


### PR DESCRIPTION
After updating an Autosuggest widget with a new suggestions fn, it still uses the previous fn, because it only saves the suggestion fn in the constructor. The attached patch resets `suggestions`, as well as `onFocus`, `onChange` and `onBlur` from `componentWillReceiveProps`. Maybe more state needs to be reset in order to guarantee correctness.