### PR TITLE
Add escape hatch to avoid conflict with FastClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Check out the [standalone example](https://github.com/moroshko/react-autosuggest
 * [`id`](#idOption)
 * [`scrollBar`](#scrollBarOption)
 * [`theme`](#themeOption)
+* [`ignoredByFastClick`](#ignoredByFastClickOption)
 
 <a name="suggestionsOption"></a>
 #### suggestions (required)
@@ -453,6 +454,13 @@ The following diagrams explain the classes above.
     |  +----------------------------------------------------------------------+  |
     |                                                                            |
     +----------------------------------------------------------------------------+
+
+<a name="ignoredByFastClickOption"></a>
+#### ignoredByFastClick (optional)
+
+Defaults to `false`.
+Set it to `true` to avoid conflict with [fastclick](https://github.com/ftlabs/fastclick) if you are using it.
+If `true`, each suggestion list item has `needsclick` class, which makes fastclick ignore the elements.
 
 ## Development
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -18,7 +18,8 @@ export default class Autosuggest extends Component {
     cache: PropTypes.bool,                  // Set it to false to disable in-memory caching
     id: PropTypes.string,                   // Used in aria-* attributes. If multiple Autosuggest's are rendered on a page, they must have unique ids.
     scrollBar: PropTypes.bool,              // Set it to true when the suggestions container can have a scroll bar
-    theme: PropTypes.object                 // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    theme: PropTypes.object,                // Custom theme. See: https://github.com/markdalgleish/react-themeable
+    ignoredByFastClick: PropTypes.bool      // Set it to true to avoid conflict with FastClick
   }
 
   static defaultProps = {
@@ -37,8 +38,10 @@ export default class Autosuggest extends Component {
       suggestionIsFocused: 'react-autosuggest__suggestion--focused',
       section: 'react-autosuggest__suggestions-section',
       sectionName: 'react-autosuggest__suggestions-section-name',
-      sectionSuggestions: 'react-autosuggest__suggestions-section-suggestions'
-    }
+      sectionSuggestions: 'react-autosuggest__suggestions-section-suggestions',
+      needsclick: 'needsclick'
+    },
+    ignoredByFastClick: false
   }
 
   constructor(props) {
@@ -482,7 +485,8 @@ export default class Autosuggest extends Component {
       const styles = theme(suggestionIndex, 'suggestion',
         sectionIndex === this.state.focusedSectionIndex &&
         suggestionIndex === this.state.focusedSuggestionIndex &&
-        'suggestionIsFocused'
+        'suggestionIsFocused',
+        this.props.ignoredByFastClick && 'needsclick'
       );
       const suggestionRef =
         this.getSuggestionRef(sectionIndex, suggestionIndex);


### PR DESCRIPTION
When using with [FastClick] on affected mobile devices/browsers,  clicking a suggestion just fires `blur` event but not `mousedown` event. It just hides the suggestion list and the input remains unchanged.

This PR adds `ignoredByFastClick` option, which, if set to `true`, makes [FastClick] ignore suggestion elements. `ignoredByFastClick` defaults to `false` to avoid compatibility issues.

I'm afraid that I can't come up with automated tests for this. ([FastClick] also does not have automated tests.)

To reproduce the problem, just load and initialize [FastClick] on `examples/dist/index.html`, then input some text and click a suggestion element on an affected device or chrome dev tool mobile simulator.

[FastClick]: https://github.com/ftlabs/fastclick