### PR TITLE
Suppress focusing with mouse hover while focusing with keyboard.

### DIFF
--- a/demo/src/components/App/components/Examples/components/Basic/autosuggest.css
+++ b/demo/src/components/App/components/Examples/components/Basic/autosuggest.css
@@ -26,6 +26,8 @@
   position: absolute;
   top: 51px;
   width: 280px;
+  max-height: 300px;
+  overflow-y: auto;
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/demo/src/components/App/components/Examples/components/Basic/languages.js
+++ b/demo/src/components/App/components/Examples/components/Basic/languages.js
@@ -1,4 +1,4 @@
-export default [
+const languages = [
   {
     name: 'C',
     year: 1972
@@ -56,3 +56,12 @@ export default [
     year: 2003
   }
 ];
+
+for (let i = 1; i <= 100; ++i) {
+  languages.push({
+    name: `Zooble ${i}`,
+    year: 2035 + i
+  });
+}
+
+export default languages;

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { inputFocused, inputBlurred, inputChanged, updateFocusedSuggestion,
+import { inputFocused, inputBlurred, inputChanged, updateFocusedSuggestion, updateFocusedUsingKeyboard,
          revealSuggestions, closeSuggestions } from './reducerAndActions';
 import Autowhatever from 'react-autowhatever';
 
@@ -10,6 +10,7 @@ function mapStateToProps(state) {
     isCollapsed: state.isCollapsed,
     focusedSectionIndex: state.focusedSectionIndex,
     focusedSuggestionIndex: state.focusedSuggestionIndex,
+    focusedUsingKeyboard: state.focusedUsingKeyboard,
     valueBeforeUpDown: state.valueBeforeUpDown,
     lastAction: state.lastAction
   };
@@ -26,8 +27,11 @@ function mapDispatchToProps(dispatch) {
     inputChanged: (shouldRenderSuggestions, lastAction) => {
       dispatch(inputChanged(shouldRenderSuggestions, lastAction));
     },
-    updateFocusedSuggestion: (sectionIndex, suggestionIndex, value) => {
-      dispatch(updateFocusedSuggestion(sectionIndex, suggestionIndex, value));
+    updateFocusedSuggestion: (sectionIndex, suggestionIndex, value, isKeyboard) => {
+      dispatch(updateFocusedSuggestion(sectionIndex, suggestionIndex, value, isKeyboard));
+    },
+    updateFocusedUsingKeyboard: (isKeyboard) => {
+      dispatch(updateFocusedUsingKeyboard(isKeyboard));
     },
     revealSuggestions: () => {
       dispatch(revealSuggestions());
@@ -59,6 +63,7 @@ class Autosuggest extends Component {
     isCollapsed: PropTypes.bool.isRequired,
     focusedSectionIndex: PropTypes.number,
     focusedSuggestionIndex: PropTypes.number,
+    focusedUsingKeyboard: PropTypes.bool,
     valueBeforeUpDown: PropTypes.string,
     lastAction: PropTypes.string,
 
@@ -66,6 +71,7 @@ class Autosuggest extends Component {
     inputBlurred: PropTypes.func.isRequired,
     inputChanged: PropTypes.func.isRequired,
     updateFocusedSuggestion: PropTypes.func.isRequired,
+    updateFocusedUsingKeyboard: PropTypes.func.isRequired,
     revealSuggestions: PropTypes.func.isRequired,
     closeSuggestions: PropTypes.func.isRequired
   };
@@ -177,9 +183,9 @@ class Autosuggest extends Component {
       suggestions, renderSuggestion, inputProps, shouldRenderSuggestions,
       onSuggestionSelected, multiSection, renderSectionTitle, id,
       getSectionSuggestions, focusInputOnSuggestionClick, theme, isFocused,
-      isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
+      isCollapsed, focusedSectionIndex, focusedSuggestionIndex, focusedUsingKeyboard,
       valueBeforeUpDown, inputFocused, inputBlurred, inputChanged,
-      updateFocusedSuggestion, revealSuggestions, closeSuggestions
+      updateFocusedSuggestion, updateFocusedUsingKeyboard, revealSuggestions, closeSuggestions
     } = this.props;
     const { value, onBlur, onFocus, onKeyDown } = inputProps;
     const isOpen = isFocused && !isCollapsed && this.willRenderSuggestions();
@@ -226,7 +232,7 @@ class Autosuggest extends Component {
                 valueBeforeUpDown :
                 this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
 
-              updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value);
+              updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value, true);
               this.maybeCallOnChange(event, newValue, event.key === 'ArrowDown' ? 'down' : 'up');
             }
             event.preventDefault();
@@ -274,10 +280,19 @@ class Autosuggest extends Component {
       }
     };
     const onMouseEnter = (event, { sectionIndex, itemIndex }) => {
-      updateFocusedSuggestion(sectionIndex, itemIndex);
+      if (!focusedUsingKeyboard) {
+        updateFocusedSuggestion(sectionIndex, itemIndex);
+      }
     };
     const onMouseLeave = () => {
-      updateFocusedSuggestion(null, null);
+      if (!focusedUsingKeyboard) {
+        updateFocusedSuggestion(null, null);
+      }
+    };
+    const onMouseMove = () => {
+      if (focusedUsingKeyboard) {
+        updateFocusedUsingKeyboard(false);
+      }
     };
     const onMouseDown = () => {
       this.justClickedOnSuggestion = true;
@@ -318,6 +333,7 @@ class Autosuggest extends Component {
         onMouseLeave,
         onMouseDown,
         onTouchStart: onMouseDown, // Because on iOS `onMouseDown` is not triggered
+        onMouseMove,
         onClick
       };
     };

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -289,11 +289,9 @@ class Autosuggest extends Component {
         updateFocusedSuggestion(null, null);
       }
     };
-    const onMouseMove = () => {
-      if (focusedUsingKeyboard) {
-        updateFocusedUsingKeyboard(false);
-      }
-    };
+    const onMouseMove = (focusedUsingKeyboard
+      ? () => updateFocusedUsingKeyboard(false)
+      : undefined);
     const onMouseDown = () => {
       this.justClickedOnSuggestion = true;
     };

--- a/src/reducerAndActions.js
+++ b/src/reducerAndActions.js
@@ -2,6 +2,7 @@ const INPUT_FOCUSED = 'INPUT_FOCUSED';
 const INPUT_BLURRED = 'INPUT_BLURRED';
 const INPUT_CHANGED = 'INPUT_CHANGED';
 const UPDATE_FOCUSED_SUGGESTION = 'UPDATE_FOCUSED_SUGGESTION';
+const UPDATE_FOCUSED_USING_KEYBOARD = 'UPDATE_FOCUSED_USING_KEYBOARD';
 const REVEAL_SUGGESTIONS = 'REVEAL_SUGGESTIONS';
 const CLOSE_SUGGESTIONS = 'CLOSE_SUGGESTIONS';
 
@@ -26,12 +27,20 @@ export function inputChanged(shouldRenderSuggestions, lastAction) {
   };
 }
 
-export function updateFocusedSuggestion(sectionIndex, suggestionIndex, value) {
+export function updateFocusedSuggestion(sectionIndex, suggestionIndex, value, isKeyboard) {
   return {
     type: UPDATE_FOCUSED_SUGGESTION,
     sectionIndex,
     suggestionIndex,
-    value
+    value,
+    isKeyboard
+  };
+}
+
+export function updateFocusedUsingKeyboard(isKeyboard) {
+  return {
+    type: UPDATE_FOCUSED_USING_KEYBOARD,
+    isKeyboard
   };
 }
 
@@ -78,7 +87,7 @@ export default function reducer(state, action) {
       };
 
     case UPDATE_FOCUSED_SUGGESTION: {
-      const { value, sectionIndex, suggestionIndex } = action;
+      const { value, sectionIndex, suggestionIndex, isKeyboard } = action;
       const valueBeforeUpDown =
         state.valueBeforeUpDown === null && typeof value !== 'undefined'
           ? value
@@ -88,7 +97,17 @@ export default function reducer(state, action) {
         ...state,
         focusedSectionIndex: sectionIndex,
         focusedSuggestionIndex: suggestionIndex,
-        valueBeforeUpDown
+        valueBeforeUpDown,
+        focusedUsingKeyboard: isKeyboard
+      };
+    }
+
+    case UPDATE_FOCUSED_USING_KEYBOARD: {
+      const { isKeyboard } = action;
+
+      return {
+        ...state,
+        focusedUsingKeyboard: isKeyboard
       };
     }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -130,6 +130,10 @@ export function mouseDownSuggestion(suggestionIndex) {
   Simulate.mouseDown(getSuggestion(suggestionIndex));
 }
 
+export function mouseMoveSuggestion(suggestionIndex) {
+  Simulate.mouseMove(getSuggestion(suggestionIndex));
+}
+
 export function clickSuggestion(suggestionIndex) {
   mouseEnterSuggestion(suggestionIndex);
   mouseDownSuggestion(suggestionIndex);

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -13,6 +13,7 @@ import {
   expectFocusedSuggestion,
   mouseEnterSuggestion,
   mouseLeaveSuggestion,
+  mouseMoveSuggestion,
   clickSuggestion,
   focusInput,
   blurInput,
@@ -161,6 +162,27 @@ describe('Plain list Autosuggest', () => {
     it('should focus on the first suggestion', () => {
       clickDown();
       expectFocusedSuggestion('Perl');
+    });
+
+    it('should ignore mouseenter immediately following keyboard click', () => {
+      clickDown();
+
+      // Imagine this has triggered a scroll and results in leave/enter events.
+      mouseLeaveSuggestion(1);
+      mouseEnterSuggestion(2);
+
+      expectFocusedSuggestion('Perl');
+    });
+
+    it('should not ignore mouseenter if mouse moves first', () => {
+      clickDown();
+
+      // This time the leave/enter events are caused by a mouse movement.
+      mouseMoveSuggestion(1);
+      mouseLeaveSuggestion(1);
+      mouseEnterSuggestion(2);
+
+      expectFocusedSuggestion('Python');
     });
 
     it('should focus on the next suggestion', () => {


### PR DESCRIPTION
This is needed to avoid a UI glitch when setting suggestions list has a scrollbar (because it has max-height and overflow style properties). On the demo page the languages sample has had 100 extra entries added to demonstrate scrolling.

To see the issue it is supposed to address:
1. Enter `Z` to show 100 suggestions.
2. Use arrow keys to set the focused selection
3. Move mouse cursor over the suggestion list (this should have no immediate effect)
4. Use keys to move focus down until the suggestion list scrolls

When I do this in Chrome, the suggestion that falls under the mouse cursor because of the scrolling gets the focus, rather than the intended one.

The way this change attempts to fix this is by suppressing the setting of focus on hover immediately following change of focus via the keyboard.
