### PR TITLE
Always render suggestions – fix #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ class Example extends React.Component {
 * [`renderSuggestion`](#renderSuggestionProp)
 * [`inputProps`](#inputPropsProp)
 * [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp)
+* [`alwaysRenderSuggestions`](#alwaysRenderSuggestionsProp)
 * [`multiSection`](#multiSectionProp)
 * [`renderSectionTitle`](#renderSectionTitleProp)
 * [`getSectionSuggestions`](#getSectionSuggestionsProp)
@@ -330,6 +331,15 @@ function shouldRenderSuggestions(value) {
   return value.trim().length > 2;
 }
 ```
+
+When `shouldRenderSuggestions` returns true, suggestions will be rendered only when the input field is focused. If you would like to render suggestions regardless of whether the input field is focused or not, set `alwaysRenderSuggestions={true}` (`shouldRenderSuggestions` is ignored in this case).
+
+<a name="alwaysRenderSuggestionsProp"></a>
+#### alwaysRenderSuggestions (optional)
+
+By default, suggestions are rendered only if the input field is focused.
+
+If you'd like to _always_ display suggestions, set `alwaysRenderSuggestions={true}`.
 
 <a name="multiSectionProp"></a>
 #### multiSection (optional)

--- a/demo/src/components/App/components/Examples/Examples.js
+++ b/demo/src/components/App/components/Examples/Examples.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Basic from 'Basic/Basic';
 import MultipleSections from 'MultipleSections/MultipleSections';
 import CustomRender from 'CustomRender/CustomRender';
+import AlwaysOpen from 'AlwaysOpen/AlwaysOpen';
 
 export default function Examples() {
   return (
@@ -14,6 +15,7 @@ export default function Examples() {
       <Basic />
       <MultipleSections />
       <CustomRender />
+      <AlwaysOpen />
     </div>
   );
 }

--- a/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.js
+++ b/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.js
@@ -42,6 +42,7 @@ export default class AlwaysOpen extends Component {
 
     this.onChange = this.onChange.bind(this);
     this.onSuggestionsUpdateRequested = this.onSuggestionsUpdateRequested.bind(this);
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
     this.onOpenModal = this.onToggleModal.bind(this, true);
     this.onCloseModal = this.onToggleModal.bind(this, false);
     this.onClickOverlay = this.onClickOverlay.bind(this);
@@ -75,10 +76,18 @@ export default class AlwaysOpen extends Component {
   }
 
   onSuggestionsUpdateRequested({ value }) {
-    console.log(value);
     this.setState({
       suggestions: getSuggestions(value)
     });
+  }
+
+  onSuggestionSelected(e, { suggestionValue }) {
+    this.setState({
+      value: suggestionValue,
+      suggestions: getSuggestions(suggestionValue)
+    });
+
+    this.onCloseModal();
   }
 
   render() {
@@ -102,11 +111,11 @@ export default class AlwaysOpen extends Component {
         <div className={styles.autosuggest}>
           <a href="javascript:void(0)" onClick={this.onOpenModal} className={styles.button}>View suggestions</a>
           {isOpen ? (
-            <div className={styles.overlay} data-overlay onClick={this.onClickOverlay}>
+            <div className={styles.overlay} data-overlay={true} onClick={this.onClickOverlay}>
               <div className={styles.modal}>
                 <Autosuggest suggestions={suggestions}
                              onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
-                             onSuggestionSelected={this.onCloseModal}
+                             onSuggestionSelected={this.onSuggestionSelected}
                              getSuggestionValue={getSuggestionValue}
                              renderSuggestion={renderSuggestion}
                              inputProps={inputProps}

--- a/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.js
+++ b/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.js
@@ -1,0 +1,134 @@
+import styles from './AlwaysOpen.less';
+
+import React, { Component } from 'react';
+import isMobile from 'ismobilejs';
+import Autosuggest from 'AutosuggestContainer';
+import languages from './languages';
+import { escapeRegexCharacters } from 'utils/utils';
+
+const focusInputOnSuggestionClick = !isMobile.any;
+
+function getSuggestions(value) {
+  const escapedValue = escapeRegexCharacters(value.trim());
+
+  if (escapedValue === '') {
+    return languages;
+  }
+
+  const regex = new RegExp('^' + escapedValue, 'i');
+
+  return languages.filter(language => regex.test(language.name));
+}
+
+function getSuggestionValue(suggestion) {
+  return suggestion.name;
+}
+
+function renderSuggestion(suggestion) {
+  return (
+    <span>{suggestion.name}</span>
+  );
+}
+
+export default class AlwaysOpen extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      isOpen: false,
+      value: '',
+      suggestions: getSuggestions('')
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.onSuggestionsUpdateRequested = this.onSuggestionsUpdateRequested.bind(this);
+    this.onOpenModal = this.onToggleModal.bind(this, true);
+    this.onCloseModal = this.onToggleModal.bind(this, false);
+    this.onClickOverlay = this.onClickOverlay.bind(this);
+  }
+
+  onToggleModal(isOpen = !this.state.isOpen) {
+    this.setState({
+      isOpen: isOpen
+    });
+
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  }
+
+  onClickOverlay(e) {
+    const isOverlay = e.target.getAttribute('data-overlay');
+
+    if (isOverlay) {
+      this.onCloseModal();
+      e.preventDefault();
+    }
+  }
+
+  onChange(event, { newValue }) {
+    this.setState({
+      value: newValue
+    });
+  }
+
+  onSuggestionsUpdateRequested({ value }) {
+    console.log(value);
+    this.setState({
+      suggestions: getSuggestions(value)
+    });
+  }
+
+  render() {
+    const { isOpen, value, suggestions } = this.state;
+    const inputProps = {
+      placeholder: 'Type \'c\'',
+      value,
+      onChange: this.onChange
+    };
+
+    return (
+      <div id="basic-example" className={styles.container}>
+        <div className={styles.textContainer}>
+          <div className={styles.title}>
+            Always open
+          </div>
+          <div className={styles.description}>
+            Propose default suggestions even if the user hasn’t typed yet
+          </div>
+        </div>
+        <div className={styles.autosuggest}>
+          <a href="javascript:void(0)" onClick={this.onOpenModal} className={styles.button}>View suggestions</a>
+          {isOpen ? (
+            <div className={styles.overlay} data-overlay onClick={this.onClickOverlay}>
+              <div className={styles.modal}>
+                <Autosuggest suggestions={suggestions}
+                             onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
+                             onSuggestionSelected={this.onCloseModal}
+                             getSuggestionValue={getSuggestionValue}
+                             renderSuggestion={renderSuggestion}
+                             inputProps={inputProps}
+                             alwaysRenderSuggestions={true}
+                             focusInputOnSuggestionClick={focusInputOnSuggestionClick}
+                             id="alwaysopen-example"
+                             theme={{
+                               container: 'react-autosuggest__container',
+                               containerOpen: 'react-autosuggest__container--open',
+                               input: 'react-autosuggest__input',
+                               suggestionsContainer: `react-autosuggest__suggestions-container ${styles.suggestionsContainer}`,
+                               suggestion: 'react-autosuggest__suggestion',
+                               suggestionFocused: 'react-autosuggest__suggestion--focused',
+                               sectionContainer: 'react-autosuggest__section-container',
+                               sectionTitle: 'react-autosuggest__section-title',
+                               sectionSuggestionsContainer: 'react-autosuggest__section-suggestions-container'
+                             }} />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.less
+++ b/demo/src/components/App/components/Examples/components/AlwaysOpen/AlwaysOpen.less
@@ -1,0 +1,83 @@
+@import '~variables';
+
+.button {
+  color: #209FD3;
+  text-decoration: none;
+}
+
+.suggestionsContainer {
+  position: static;
+  max-height: 300px;
+  overflow-y: scroll;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 100;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.modal {
+  position: absolute;
+  top: 10vh;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 101;
+}
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  width: 34 * @columns;
+  margin: (11 * @rows) (0.5 * @column) 0;
+
+  @media @examples-vertical {
+    flex-direction: column;
+    width: 14 * @columns;
+    margin-top: 9 * @rows;
+  }
+
+  @media @small {
+    margin-top: 7 * @rows;
+  }
+}
+
+.textContainer {
+  display: flex;
+  flex-direction: column;
+  width: 15 * @columns;
+}
+
+.title {
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 5 * @rows;
+
+  @media @small {
+    font-size: 25px;
+  }
+}
+
+.description {
+  margin-top: @row;
+  font-size: 20px;
+}
+
+.codepenLink {
+  margin-top: @row;
+  font-size: 20px;
+  color: #209FD3;
+}
+
+.autosuggest {
+  margin-top: 6 * @rows;
+
+  @media @examples-vertical {
+    margin-top: 3 * @rows;
+    margin-left: 0;
+  }
+}

--- a/demo/src/components/App/components/Examples/components/AlwaysOpen/languages.js
+++ b/demo/src/components/App/components/Examples/components/AlwaysOpen/languages.js
@@ -1,0 +1,58 @@
+export default [
+  {
+    name: 'C',
+    year: 1972
+  },
+  {
+    name: 'C#',
+    year: 2000
+  },
+  {
+    name: 'C++',
+    year: 1983
+  },
+  {
+    name: 'Clojure',
+    year: 2007
+  },
+  {
+    name: 'Elm',
+    year: 2012
+  },
+  {
+    name: 'Go',
+    year: 2009
+  },
+  {
+    name: 'Haskell',
+    year: 1990
+  },
+  {
+    name: 'Java',
+    year: 1995
+  },
+  {
+    name: 'Javascript',
+    year: 1995
+  },
+  {
+    name: 'Perl',
+    year: 1987
+  },
+  {
+    name: 'PHP',
+    year: 1995
+  },
+  {
+    name: 'Python',
+    year: 1991
+  },
+  {
+    name: 'Ruby',
+    year: 1995
+  },
+  {
+    name: 'Scala',
+    year: 2003
+  }
+];

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -22,6 +22,7 @@ class Autosuggest extends Component {
     renderSuggestion: PropTypes.func.isRequired,
     inputProps: PropTypes.object.isRequired,
     shouldRenderSuggestions: PropTypes.func.isRequired,
+    alwaysRenderSuggestions: PropTypes.bool.isRequired,
     onSuggestionSelected: PropTypes.func.isRequired,
     multiSection: PropTypes.bool.isRequired,
     renderSectionTitle: PropTypes.func.isRequired,

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -61,14 +61,16 @@ class Autosuggest extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.suggestions !== this.props.suggestions) {
-      const { suggestions, inputProps, shouldRenderSuggestions,
-              isCollapsed, revealSuggestions, lastAction } = nextProps;
+      const {
+        suggestions, inputProps, shouldRenderSuggestions, isCollapsed,
+        revealSuggestions, lastAction, alwaysRenderSuggestions
+      } = nextProps;
       const { value } = inputProps;
 
-      if (suggestions.length > 0 && shouldRenderSuggestions(value)) {
+      if (alwaysRenderSuggestions || suggestions.length > 0 && shouldRenderSuggestions(value)) {
         this.maybeFocusFirstSuggestion();
 
-        if (isCollapsed && lastAction !== 'click' && lastAction !== 'enter') {
+        if (alwaysRenderSuggestions || isCollapsed && lastAction !== 'click' && lastAction !== 'enter') {
           revealSuggestions();
         }
       }
@@ -226,10 +228,10 @@ class Autosuggest extends Component {
       theme, isFocused, isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
       valueBeforeUpDown, inputFocused, inputBlurred, inputChanged,
       updateFocusedSuggestion, revealSuggestions, closeSuggestions,
-      getSuggestionValue
+      getSuggestionValue, alwaysRenderSuggestions
     } = this.props;
     const { value, onBlur, onFocus, onKeyDown } = inputProps;
-    const isOpen = isFocused && !isCollapsed && this.willRenderSuggestions();
+    const isOpen = alwaysRenderSuggestions || isFocused && !isCollapsed && this.willRenderSuggestions();
     const items = (isOpen ? suggestions : []);
     const autowhateverInputProps = {
       ...inputProps,

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -64,6 +64,7 @@ export default class AutosuggestContainer extends Component {
       }
     },
     shouldRenderSuggestions: PropTypes.func,
+    alwaysRenderSuggestions: PropTypes.bool,
     onSuggestionSelected: PropTypes.func,
     multiSection: PropTypes.bool,
     renderSectionTitle: PropTypes.func,
@@ -77,6 +78,7 @@ export default class AutosuggestContainer extends Component {
   static defaultProps = {
     onSuggestionsUpdateRequested: noop,
     shouldRenderSuggestions: value => value.trim().length > 0,
+    alwaysRenderSuggestions: false,
     onSuggestionSelected: noop,
     multiSection: false,
     renderSectionTitle() {
@@ -118,13 +120,14 @@ export default class AutosuggestContainer extends Component {
       onSuggestionsUpdateRequested, getSuggestionValue, renderSuggestion,
       renderSectionTitle, getSectionSuggestions, inputProps,
       onSuggestionSelected, focusInputOnSuggestionClick, focusFirstSuggestion,
-      theme, id
+      alwaysRenderSuggestions, theme, id
     } = this.props;
 
     return (
       <Autosuggest
         multiSection={multiSection}
         shouldRenderSuggestions={shouldRenderSuggestions}
+        alwaysRenderSuggestions={alwaysRenderSuggestions}
         suggestions={suggestions}
         onSuggestionsUpdateRequested={onSuggestionsUpdateRequested}
         getSuggestionValue={getSuggestionValue}

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -4,6 +4,7 @@ import reducer from './reducerAndActions';
 import Autosuggest from './Autosuggest';
 
 function noop() {}
+const returnTrue = () => true;
 
 const defaultTheme = {
   container: 'react-autosuggest__container',
@@ -93,12 +94,13 @@ export default class AutosuggestContainer extends Component {
     id: '1'
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
+    const { alwaysRenderSuggestions } = props;
 
     const initialState = {
       isFocused: false,
-      isCollapsed: true,
+      isCollapsed: !alwaysRenderSuggestions,
       focusedSectionIndex: null,
       focusedSuggestionIndex: null,
       valueBeforeUpDown: null,
@@ -126,7 +128,7 @@ export default class AutosuggestContainer extends Component {
     return (
       <Autosuggest
         multiSection={multiSection}
-        shouldRenderSuggestions={shouldRenderSuggestions}
+        shouldRenderSuggestions={alwaysRenderSuggestions ? returnTrue : shouldRenderSuggestions}
         alwaysRenderSuggestions={alwaysRenderSuggestions}
         suggestions={suggestions}
         onSuggestionsUpdateRequested={onSuggestionsUpdateRequested}

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -48,9 +48,11 @@ export const shouldRenderSuggestions = sinon.spy(value => {
   return value.trim().length > 0 && value[0] !== ' ';
 });
 
-export const toggleAlwaysRenderSuggestions = sinon.spy((toggle, callback) => {
+export const setAlwaysRenderSuggestions = sinon.spy((toggle, callback) => {
   app.setState({
-    alwaysRenderSuggestions: toggle
+    alwaysRenderSuggestions: toggle,
+    // Using "elm" to retrieve suggestions even when input is blank.
+    suggestions: getMatchingLanguages(app.state.value || 'elm')
   }, callback);
 });
 

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -48,6 +48,12 @@ export const shouldRenderSuggestions = sinon.spy(value => {
   return value.trim().length > 0 && value[0] !== ' ';
 });
 
+export const toggleAlwaysRenderSuggestions = sinon.spy((toggle, callback) => {
+  app.setState({
+    alwaysRenderSuggestions: toggle
+  }, callback);
+});
+
 export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
   app.setState({
     suggestions: getMatchingLanguages(value)
@@ -64,7 +70,8 @@ export default class AutosuggestApp extends Component {
 
     this.state = {
       value: '',
-      suggestions: getMatchingLanguages('')
+      suggestions: getMatchingLanguages(''),
+      alwaysRenderSuggestions: false
     };
   }
 
@@ -75,7 +82,7 @@ export default class AutosuggestApp extends Component {
   }
 
   render() {
-    const { value, suggestions } = this.state;
+    const { value, suggestions, alwaysRenderSuggestions } = this.state;
     const inputProps = {
       id: 'my-awesome-autosuggest',
       placeholder: 'Type a programming language',
@@ -93,6 +100,7 @@ export default class AutosuggestApp extends Component {
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}
         shouldRenderSuggestions={shouldRenderSuggestions}
+        alwaysRenderSuggestions={alwaysRenderSuggestions}
         onSuggestionSelected={onSuggestionSelected}
         ref={this.storeAutosuggestReference} />
     );

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -32,7 +32,7 @@ import AutosuggestApp, {
   onChange,
   onBlur,
   shouldRenderSuggestions,
-  alwaysRenderSuggestions,
+  setAlwaysRenderSuggestions,
   onSuggestionSelected,
   onSuggestionsUpdateRequested
 } from './AutosuggestApp';
@@ -496,24 +496,30 @@ describe('Default Autosuggest', () => {
   describe('when alwaysRenderSuggestions is true', () => {
     beforeEach(done => {
       setAlwaysRenderSuggestions(true, done);
-      focusAndSetInputValue('e');
-      blurInput();
     });
 
     afterEach(done => {
       setAlwaysRenderSuggestions(false, done);
     });
 
-    it('should render suggestions by default', () => {
-      expectSuggestions(['Elm']);
-    });
-
     it('should render suggestions when input is focused', () => {
-      focusInput();
+      focusAndSetInputValue('e');
       expectSuggestions(['Elm']);
     });
 
     it('should render suggestions when input is blurred', () => {
+      focusAndSetInputValue('e');
+      blurInput();
+      expectSuggestions(['Elm']);
+    });
+
+    it('should render suggestions even when input is blank and focused', () => {
+      focusAndSetInputValue('');
+      expectSuggestions(['Elm']);
+    });
+
+    it('should render suggestions even when input is blank and blurred', () => {
+      focusAndSetInputValue('');
       blurInput();
       expectSuggestions(['Elm']);
     });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -502,6 +502,10 @@ describe('Default Autosuggest', () => {
       setAlwaysRenderSuggestions(false, done);
     });
 
+    it('should render suggestions initially', () => {
+      expectSuggestions(['Elm']);
+    });
+
     it('should render suggestions when input is focused', () => {
       focusAndSetInputValue('e');
       expectSuggestions(['Elm']);
@@ -522,6 +526,56 @@ describe('Default Autosuggest', () => {
       focusAndSetInputValue('');
       blurInput();
       expectSuggestions(['Elm']);
+    });
+
+    describe('when pressing Down', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('p');
+      });
+
+      it('should focus on the first suggestion', () => {
+        clickDown();
+        expectFocusedSuggestion('Perl');
+      });
+    });
+
+    describe('when pressing Up', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('p');
+      });
+
+      it('should focus on the last suggestion', () => {
+        clickUp();
+        expectFocusedSuggestion('Python');
+      });
+    });
+
+    describe('when pressing Enter', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('p');
+      });
+
+      it('should not hide suggestions if there is a focused suggestion', () => {
+        clickDown();
+        clickEnter();
+        expectSuggestions(['Perl']);
+      });
+
+      it('should not hide suggestions if there is no focused suggestion', () => {
+        clickEnter();
+        expectSuggestions(['Perl', 'PHP', 'Python']);
+      });
+    });
+
+    describe('when suggestion is clicked', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('p');
+        clickSuggestion(1);
+      });
+
+      it('should not hide suggestions', () => {
+        expectSuggestions(['PHP']);
+      });
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -32,6 +32,7 @@ import AutosuggestApp, {
   onChange,
   onBlur,
   shouldRenderSuggestions,
+  alwaysRenderSuggestions,
   onSuggestionSelected,
   onSuggestionsUpdateRequested
 } from './AutosuggestApp';
@@ -489,6 +490,32 @@ describe('Default Autosuggest', () => {
     it('should hide suggestions when `false` is returned', () => {
       focusAndSetInputValue(' e');
       expectSuggestions([]);
+    });
+  });
+
+  describe('when alwaysRenderSuggestions is true', () => {
+    beforeEach(done => {
+      setAlwaysRenderSuggestions(true, done);
+      focusAndSetInputValue('e');
+      blurInput();
+    });
+
+    afterEach(done => {
+      setAlwaysRenderSuggestions(false, done);
+    });
+
+    it('should render suggestions by default', () => {
+      expectSuggestions(['Elm']);
+    });
+
+    it('should render suggestions when input is focused', () => {
+      focusInput();
+      expectSuggestions(['Elm']);
+    });
+
+    it('should render suggestions when input is blurred', () => {
+      blurInput();
+      expectSuggestions(['Elm']);
     });
   });
 


### PR DESCRIPTION
Hey hey,

this is a PR to fix #133. It implements a new `alwaysRenderSuggestions` boolean prop, as we discussed. When `alwaysRenderSuggestions={true}`, the checks to decide whether to render the suggestions are bypassed. Also comes with some documentation on this new prop, and relevant tests.

I'd be keen to get a review of whether [the tests are relevant and thorough enough](https://github.com/ThibWeb/react-autosuggest/blob/feature/always-render-suggestions/test/plain-list/AutosuggestApp.test.js#L431), and make sure this new prop [is used in the right places](https://github.com/moroshko/react-autosuggest/pull/155/commits/0b0a86cebe3391adabf995bb02323ed478381877).

Also two things occurred to me while writing this PR:

- Having an example for this would only be relevant if it came with the kind of UI this is useful for. Do we want to make one? (another way to see this would be to have a list of "projects `react-autosuggest` is used on" somewhere).
- It might or might not be be obvious that in order for this to be useful, you need to have a list of suggestions to display _even when the user hasn't typed anything yet_ (otherwise there's nothing to display, doh). Does this need to be stated in the docs?