### PR TITLE
Tab to select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 demo/dist
 npm-debug.log
 .happypack
+.idea

--- a/README.md
+++ b/README.md
@@ -418,14 +418,12 @@ where `isMobile` is a boolean describing whether Autosuggest operates on a mobil
 <a name="tabToSelect"></a>
 #### tabToSelect (optional)
 
-Disabled by default, `tabToSelect={true}` will select the highlighted suggestion on Tab. Suggestions will not close.
+Disabled by default, `tabToSelect={true}` will select the highlighted suggestion on Tab.
 
 
 ```xml
 <Autosuggest tabToSelect={true} ... />
 ```
-
-where `isMobile` is a boolean describing whether Autosuggest operates on a mobile device or not. You can use [kaimallea/isMobile](https://github.com/kaimallea/isMobile), for example, to determine that.
 
 <a name="themeProp"></a>
 #### theme (optional)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const languages = [
 function getSuggestions(value) {
   const inputValue = value.trim().toLowerCase();
   const inputLength = inputValue.length;
-  
+
   return inputLength === 0 ? [] : languages.filter(lang =>
     lang.name.toLowerCase().slice(0, inputLength) === inputValue
   );
@@ -139,6 +139,7 @@ class Example extends React.Component {
 * [`getSectionSuggestions`](#getSectionSuggestionsProp)
 * [`onSuggestionSelected`](#onSuggestionSelectedProp)
 * [`focusInputOnSuggestionClick`](#focusInputOnSuggestionClickProp)
+* [`tabToSelect`](#tabToSelect)
 * [`theme`](#themeProp)
 * [`id`](#idProp)
 
@@ -232,6 +233,7 @@ where:
   * `'type'` - usually means that user typed something, but can also be that they pressed Backspace, pasted something into the field, etc.
   * `'click'` - user clicked (or tapped) a suggestion
   * `'enter'` - user pressed Enter
+  * `'tab'` - user pressed Tab (requires `tabToSelect={true}`)
   * `'escape'` - user pressed Escape
   * `'blur'` - input lost focus
 
@@ -394,6 +396,7 @@ where:
 * `method` - string describing how user selected the suggestion. The possible values are:
   * `'click'` - user clicked (or tapped) on the suggestion
   * `'enter'` - user selected the suggestion using Enter
+  * `'tab'` - user selected the suggestion using Tab (requires `tabToSelect={true}`)
 
 <a name="focusInputOnSuggestionClickProp"></a>
 #### focusInputOnSuggestionClick (optional)
@@ -408,6 +411,18 @@ You might want to do something like this:
 
 ```xml
 <Autosuggest focusInputOnSuggestionClick={!isMobile} ... />
+```
+
+where `isMobile` is a boolean describing whether Autosuggest operates on a mobile device or not. You can use [kaimallea/isMobile](https://github.com/kaimallea/isMobile), for example, to determine that.
+
+<a name="tabToSelect"></a>
+#### tabToSelect (optional)
+
+Disabled by default, `tabToSelect={true}` will select the highlighted suggestion on Tab. Suggestions will not close.
+
+
+```xml
+<Autosuggest tabToSelect={true} ... />
 ```
 
 where `isMobile` is a boolean describing whether Autosuggest operates on a mobile device or not. You can use [kaimallea/isMobile](https://github.com/kaimallea/isMobile), for example, to determine that.

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -233,7 +233,7 @@ class Autosuggest extends Component {
             event.preventDefault();
             break;
           case 'Tab': {
-            if(tabToSelect){
+            if (tabToSelect) {
               event.preventDefault();
               const focusedSuggestion = this.getFocusedSuggestion();
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -51,6 +51,7 @@ class Autosuggest extends Component {
     renderSectionTitle: PropTypes.func.isRequired,
     getSectionSuggestions: PropTypes.func.isRequired,
     focusInputOnSuggestionClick: PropTypes.bool.isRequired,
+    tabToSelect: PropTypes.bool.isRequired,
     theme: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     inputRef: PropTypes.func.isRequired,
@@ -83,7 +84,7 @@ class Autosuggest extends Component {
       const { value } = inputProps;
 
       if (isCollapsed && lastAction !== 'click' && lastAction !== 'enter' &&
-          suggestions.length > 0 && shouldRenderSuggestions(value)) {
+        lastAction !== 'tab' && suggestions.length > 0 && shouldRenderSuggestions(value)) {
         revealSuggestions();
       }
     }
@@ -176,8 +177,8 @@ class Autosuggest extends Component {
     const {
       suggestions, renderSuggestion, inputProps, shouldRenderSuggestions,
       onSuggestionSelected, multiSection, renderSectionTitle, id,
-      getSectionSuggestions, focusInputOnSuggestionClick, theme, isFocused,
-      isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
+      getSectionSuggestions, focusInputOnSuggestionClick, tabToSelect,
+      theme, isFocused, isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
       valueBeforeUpDown, inputFocused, inputBlurred, inputChanged,
       updateFocusedSuggestion, revealSuggestions, closeSuggestions
     } = this.props;
@@ -231,7 +232,24 @@ class Autosuggest extends Component {
             }
             event.preventDefault();
             break;
+          case 'Tab': {
+            if(tabToSelect){
+              event.preventDefault();
+              const focusedSuggestion = this.getFocusedSuggestion();
 
+              if (focusedSuggestion !== null) {
+                closeSuggestions('tab');
+                onSuggestionSelected(event, {
+                  suggestion: focusedSuggestion,
+                  suggestionValue: value,
+                  sectionIndex: focusedSectionIndex,
+                  method: 'tab'
+                });
+                this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'tab' });
+              }
+            }
+            break;
+          }
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -70,6 +70,7 @@ export default class AutosuggestContainer extends Component {
     renderSectionTitle: PropTypes.func,
     getSectionSuggestions: PropTypes.func,
     focusInputOnSuggestionClick: PropTypes.bool,
+    tabToSelect: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string
   };
@@ -86,6 +87,7 @@ export default class AutosuggestContainer extends Component {
       throw new Error('`getSectionSuggestions` must be provided');
     },
     focusInputOnSuggestionClick: true,
+    tabToSelect: false,
     theme: defaultTheme,
     id: '1'
   };
@@ -115,8 +117,8 @@ export default class AutosuggestContainer extends Component {
     const {
       multiSection, shouldRenderSuggestions, suggestions,
       onSuggestionsUpdateRequested, getSuggestionValue, renderSuggestion,
-      renderSectionTitle, getSectionSuggestions, inputProps,
-      onSuggestionSelected, focusInputOnSuggestionClick, theme, id
+      renderSectionTitle, getSectionSuggestions, inputProps, onSuggestionSelected,
+      focusInputOnSuggestionClick, tabToSelect, theme, id
     } = this.props;
 
     return (
@@ -132,6 +134,7 @@ export default class AutosuggestContainer extends Component {
                      inputProps={inputProps}
                      onSuggestionSelected={onSuggestionSelected}
                      focusInputOnSuggestionClick={focusInputOnSuggestionClick}
+                     tabToSelect={tabToSelect}
                      theme={mapToAutowhateverTheme(theme)}
                      id={id}
                      inputRef={this.saveInput} />

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -155,6 +155,10 @@ export function clickEnter() {
   Simulate.keyDown(data.input, { key: 'Enter' });
 }
 
+export function clickTab() {
+  Simulate.keyDown(data.input, { key: 'Tab' });
+}
+
 export function clickDown(count = 1) {
   for (let i = 0; i < count; i++) {
     Simulate.keyDown(data.input, { key: 'ArrowDown' });

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -57,11 +57,11 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
 export const tabToSelect = {
   value: false,
 
-  true(){
+  true() {
     this.value = true;
   },
 
-  false(){
+  false() {
     this.value = false;
   }
 };

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -54,6 +54,18 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
   });
 });
 
+export const tabToSelect = {
+  value: false,
+
+  true(){
+    this.value = true;
+  },
+
+  false(){
+    this.value = false;
+  }
+};
+
 export default class AutosuggestApp extends Component {
   constructor() {
     super();
@@ -84,7 +96,8 @@ export default class AutosuggestApp extends Component {
                    renderSuggestion={renderSuggestion}
                    inputProps={inputProps}
                    shouldRenderSuggestions={shouldRenderSuggestions}
-                   onSuggestionSelected={onSuggestionSelected} />
+                   onSuggestionSelected={onSuggestionSelected}
+                   tabToSelect={tabToSelect.value} />
     );
   }
 }

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -18,6 +18,7 @@ import {
   blurInput,
   clickEscape,
   clickEnter,
+  clickTab,
   clickDown,
   clickUp,
   focusAndSetInputValue,
@@ -32,7 +33,8 @@ import AutosuggestApp, {
   onBlur,
   shouldRenderSuggestions,
   onSuggestionSelected,
-  onSuggestionsUpdateRequested
+  onSuggestionsUpdateRequested,
+  tabToSelect
 } from './AutosuggestApp';
 
 describe('Plain list Autosuggest', () => {
@@ -226,6 +228,47 @@ describe('Plain list Autosuggest', () => {
     it('should not hide suggestions if there is no focused suggestion', () => {
       clickEnter();
       expectSuggestions(['Perl', 'PHP', 'Python']);
+    });
+  });
+
+  describe('when pressing Tab', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      tabToSelect.false();
+    });
+
+    describe('when tabToSelect is false', () => {
+      beforeEach(() => {
+        tabToSelect.false();
+      });
+
+      it('should not hide suggestions if there is a focused suggestion', () => {
+        clickDown();
+        clickTab();
+        expectSuggestions(['Perl', 'PHP', 'Python']);
+      });
+
+      it('should not hide suggestions if there is no focused suggestion', () => {
+        clickTab();
+        expectSuggestions(['Perl', 'PHP', 'Python']);
+      });
+    });
+
+    describe('when tabToSelect is true', () => {
+      beforeEach(() => {
+        tabToSelect.true();
+      });
+
+      it('should hide suggestions if there is a focused suggestion', () => {
+        clickDown();
+        clickTab();
+        expectSuggestions([]);
+      });
+
+      it('should not hide suggestions if there is no focused suggestion', () => {
+        clickTab();
+        expectSuggestions(['Perl', 'PHP', 'Python']);
+      });
     });
   });
 
@@ -475,6 +518,65 @@ describe('Plain list Autosuggest', () => {
       clickSuggestion(1);
       expect(getEvents()).to.deep.equal(['onChange', 'onSuggestionSelected']);
     });
+
+    describe('when tabToSelect is false', () => {
+      beforeEach(() => {
+        tabToSelect.false();
+      });
+
+      it('should not be called when Tab is pressed and suggestion is focused', () => {
+        clickDown();
+        clickTab();
+        expect(onSuggestionSelected).not.to.have.been.called;
+      });
+
+      it('should not be called when Tab is pressed and there is no focused suggestion', () => {
+        clickTab();
+        expect(onSuggestionSelected).not.to.have.been.called;
+      });
+
+
+      it('should not be called when Tab is pressed and there is no focused suggestion after Up/Down interaction', () => {
+        clickDown();
+        clickDown();
+        clickDown();
+        clickTab();
+        expect(onSuggestionSelected).not.to.have.been.called;
+      });
+
+    });
+
+    describe('when tabToSelect is true', () => {
+      beforeEach(() => {
+        tabToSelect.true();
+      });
+
+      it('should be called once with the right parameters when Tab is pressed and suggestion is focused', () => {
+        clickDown();
+        clickTab();
+        expect(onSuggestionSelected).to.have.been.calledOnce;
+        expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
+          suggestion: { name: 'Java', year: 1995 },
+          suggestionValue: 'Java',
+          sectionIndex: null,
+          method: 'tab'
+        });
+      });
+
+      it('should not be called when Tab is pressed and there is no focused suggestion', () => {
+        clickTab();
+        expect(onSuggestionSelected).not.to.have.been.called;
+      });
+
+
+      it('should not be called when Tab is pressed and there is no focused suggestion after Up/Down interaction', () => {
+        clickDown();
+        clickDown();
+        clickDown();
+        clickTab();
+        expect(onSuggestionSelected).not.to.have.been.called;
+      });
+    });
   });
 
   describe('onSuggestionsUpdateRequested', () => {
@@ -570,6 +672,52 @@ describe('Plain list Autosuggest', () => {
       onSuggestionsUpdateRequested.reset();
       focusAndSetInputValue(' ');
       expect(onSuggestionsUpdateRequested).not.to.have.been.called;
+    });
+
+    describe('when tabToSelect is false', () => {
+      beforeEach(() => {
+        tabToSelect.false();
+      });
+
+      it('should not be called when Tab is pressed and suggestion is focused', () => {
+        focusAndSetInputValue('j');
+        clickDown();
+        onSuggestionsUpdateRequested.reset();
+        clickTab();
+        expect(onSuggestionsUpdateRequested).not.to.have.been.called;
+      });
+    });
+
+    describe('when tabToSelect is true', () => {
+      beforeEach(() => {
+        tabToSelect.true();
+      });
+
+      it('should be called once with the right parameters when Tab is pressed and suggestion is focused', () => {
+        focusAndSetInputValue('j');
+        clickDown();
+        onSuggestionsUpdateRequested.reset();
+        clickTab();
+        expect(onSuggestionsUpdateRequested).to.have.been.calledOnce;
+        expect(onSuggestionsUpdateRequested).to.have.been.calledWithExactly({ value: 'Java', reason: 'tab' });
+      });
+
+      it('should not be called when Tab is pressed and there is no focused suggestion', () => {
+        focusAndSetInputValue('j');
+        onSuggestionsUpdateRequested.reset();
+        clickTab();
+        expect(onSuggestionsUpdateRequested).not.to.have.been.called;
+      });
+
+      it('should not be called when Tab is pressed and there is no focused suggestion after Up/Down interaction', () => {
+        focusAndSetInputValue('j');
+        onSuggestionsUpdateRequested.reset();
+        clickDown();
+        clickDown();
+        clickDown();
+        clickTab();
+        expect(onSuggestionsUpdateRequested).not.to.have.been.called;
+      });
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -535,7 +535,6 @@ describe('Plain list Autosuggest', () => {
         expect(onSuggestionSelected).not.to.have.been.called;
       });
 
-
       it('should not be called when Tab is pressed and there is no focused suggestion after Up/Down interaction', () => {
         clickDown();
         clickDown();
@@ -567,7 +566,6 @@ describe('Plain list Autosuggest', () => {
         clickTab();
         expect(onSuggestionSelected).not.to.have.been.called;
       });
-
 
       it('should not be called when Tab is pressed and there is no focused suggestion after Up/Down interaction', () => {
         clickDown();


### PR DESCRIPTION
## Overview

Adds a setting `tabToSelect` to allow tabbing to select suggestion.

Closes https://github.com/moroshko/react-autosuggest/issues/163

## Details

- Adds property `tabToSelect` (defaults to false)
- Sends `Tab` event type to `onSuggestionsUpdateRequested` and `onSuggestionSelected`
- Updates README documentation with setting and event types for above functions
- Adds tests for both true and false values of the setting