### PR TITLE
Add selectFirstSuggestion setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ class Example extends React.Component {
                    onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
                    getSuggestionValue={getSuggestionValue}
                    renderSuggestion={renderSuggestion}
-                   inputProps={inputProps}
-                    selectFirstSuggestion={false} />
+                   inputProps={inputProps} />
     );
   }
 }

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ where:
   * `'down'` - user pressed Down
   * `'up'` - user pressed Up
   * `'escape'` - user pressed Escape
+  * `'enter'` - user pressed Enter
   * `'click'` - user clicked (or tapped) on suggestion
   * `'type'` - none of the methods above (usually means that user typed something, but can also be that they pressed Backspace, pasted something into the field, etc.)
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ where:
   * `'up'` - user pressed Up
   * `'escape'` - user pressed Escape
   * `'click'` - user clicked (or tapped) on suggestion
-  * `'auto'` - component auto-selected first suggestion
   * `'type'` - none of the methods above (usually means that user typed something, but can also be that they pressed Backspace, pasted something into the field, etc.)
 
 <a name="shouldRenderSuggestionsProp"></a>
@@ -418,7 +417,7 @@ where `isMobile` is a boolean describing whether Autosuggest operates on a mobil
 <a name="selectFirstSuggestion"></a>
 #### selectFirstSuggestion (optional)
 
-Defaulting to false, `selectFirstSuggestion={true}` will auto-select the first suggestion in the list. When selected, [onChange](#inputPropsProp) will receive the value with method `auto`.
+Defaulting to false, `selectFirstSuggestion={true}` will highlight the first suggestion in the list.
 
 ```xml
 <Autosuggest selectFirstSuggestion={true} ... />

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ class Example extends React.Component {
 * [`getSectionSuggestions`](#getSectionSuggestionsProp)
 * [`onSuggestionSelected`](#onSuggestionSelectedProp)
 * [`focusInputOnSuggestionClick`](#focusInputOnSuggestionClickProp)
-* [`selectFirstSuggestion`](#selectFirstSuggestion)
+* [`selectFirstSuggestion`](#selectFirstSuggestionProp)
 * [`theme`](#themeProp)
 * [`id`](#idProp)
 
@@ -414,7 +414,7 @@ You might want to do something like this:
 
 where `isMobile` is a boolean describing whether Autosuggest operates on a mobile device or not. You can use [kaimallea/isMobile](https://github.com/kaimallea/isMobile), for example, to determine that.
 
-<a name="selectFirstSuggestion"></a>
+<a name="selectFirstSuggestionProp"></a>
 #### selectFirstSuggestion (optional)
 
 Defaulting to false, `selectFirstSuggestion={true}` will highlight the first suggestion in the list.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const languages = [
 function getSuggestions(value) {
   const inputValue = value.trim().toLowerCase();
   const inputLength = inputValue.length;
-  
+
   return inputLength === 0 ? [] : languages.filter(lang =>
     lang.name.toLowerCase().slice(0, inputLength) === inputValue
   );
@@ -120,7 +120,8 @@ class Example extends React.Component {
                    onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
                    getSuggestionValue={getSuggestionValue}
                    renderSuggestion={renderSuggestion}
-                   inputProps={inputProps} />
+                   inputProps={inputProps}
+                    selectFirstSuggestion={false} />
     );
   }
 }
@@ -139,6 +140,7 @@ class Example extends React.Component {
 * [`getSectionSuggestions`](#getSectionSuggestionsProp)
 * [`onSuggestionSelected`](#onSuggestionSelectedProp)
 * [`focusInputOnSuggestionClick`](#focusInputOnSuggestionClickProp)
+* [`selectFirstSuggestion`](#selectFirstSuggestion)
 * [`theme`](#themeProp)
 * [`id`](#idProp)
 
@@ -307,6 +309,7 @@ where:
   * `'up'` - user pressed Up
   * `'escape'` - user pressed Escape
   * `'click'` - user clicked (or tapped) on suggestion
+  * `'auto'` - component auto-selected first suggestion
   * `'type'` - none of the methods above (usually means that user typed something, but can also be that they pressed Backspace, pasted something into the field, etc.)
 
 <a name="shouldRenderSuggestionsProp"></a>
@@ -411,6 +414,15 @@ You might want to do something like this:
 ```
 
 where `isMobile` is a boolean describing whether Autosuggest operates on a mobile device or not. You can use [kaimallea/isMobile](https://github.com/kaimallea/isMobile), for example, to determine that.
+
+<a name="selectFirstSuggestion"></a>
+#### selectFirstSuggestion (optional)
+
+Defaulting to false, `selectFirstSuggestion={true}` will auto-select the first suggestion in the list. When selected, [onChange](#inputPropsProp) will receive the value with method `auto`.
+
+```xml
+<Autosuggest selectFirstSuggestion={true} ... />
+```
 
 <a name="themeProp"></a>
 #### theme (optional)

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -157,7 +157,7 @@ class Autosuggest extends Component {
     }
   }
 
-  maybeSelectFirstSuggestion(event, value) {
+  maybeSelectFirstSuggestion() {
     const { selectFirstSuggestion, multiSection, updateFocusedSuggestion } = this.props;
 
     if (selectFirstSuggestion) {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -83,9 +83,11 @@ class Autosuggest extends Component {
               isCollapsed, revealSuggestions, lastAction } = nextProps;
       const { value } = inputProps;
 
-      if (isCollapsed && lastAction !== 'click' && lastAction !== 'enter' &&
-          suggestions.length > 0 && shouldRenderSuggestions(value)) {
-        revealSuggestions();
+      if (suggestions.length > 0 && shouldRenderSuggestions(value)) {
+        this.maybeSelectFirstSuggestion();
+        if (isCollapsed && lastAction !== 'click' && lastAction !== 'enter') {
+          revealSuggestions();
+        }
       }
     }
   }
@@ -161,10 +163,7 @@ class Autosuggest extends Component {
     const { selectFirstSuggestion, multiSection, updateFocusedSuggestion } = this.props;
 
     if (selectFirstSuggestion) {
-      const sectionIndex = multiSection ? 0 : null;
-      const suggestionIndex = 0;
-
-      updateFocusedSuggestion(sectionIndex, suggestionIndex);
+      updateFocusedSuggestion(multiSection ? 0 : null, 0);
     }
   }
 
@@ -202,8 +201,11 @@ class Autosuggest extends Component {
       onFocus: event => {
         if (!this.justClickedOnSuggestion) {
           inputFocused(shouldRenderSuggestions(value));
-          this.maybeSelectFirstSuggestion();
           onFocus && onFocus(event);
+
+          if (suggestions.length > 0) {
+            this.maybeSelectFirstSuggestion();
+          }
         }
       },
       onBlur: event => {
@@ -225,7 +227,6 @@ class Autosuggest extends Component {
         this.maybeCallOnChange(event, value, 'type');
         inputChanged(shouldRenderSuggestions(value), 'type');
         this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'type' });
-        this.maybeSelectFirstSuggestion();
       },
       onKeyDown: (event, data) => {
         switch (event.key) {
@@ -260,7 +261,7 @@ class Autosuggest extends Component {
 
             closeSuggestions('enter');
 
-            if (focusedSuggestion) {
+            if (focusedSuggestion !== null) {
               const newValue = getSuggestionValue(focusedSuggestion);
 
               onSuggestionSelected(event, {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -243,7 +243,7 @@ class Autosuggest extends Component {
                 // valueBeforeUpDown can be null if, for example, user
                 //  hovers on the first suggestion and then pressed Up.
                 //  if that happens, use the original input value
-                newValue = valueBeforeUpDown ? valueBeforeUpDown : value;
+                newValue = (valueBeforeUpDown === null ? value : valueBeforeUpDown);
               } else {
                 newValue = this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
               }

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -237,10 +237,16 @@ class Autosuggest extends Component {
               }
             } else if (suggestions.length > 0) {
               const { newFocusedSectionIndex, newFocusedItemIndex } = data;
-              const safeValue = valueBeforeUpDown ? valueBeforeUpDown : value;
-              const newValue = newFocusedItemIndex === null ?
-                safeValue :
-                this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
+
+              let newValue;
+              if(newFocusedItemIndex === null){
+                // valueBeforeUpDown can be null if, for example, user
+                //  hovers on the first suggestion and then pressed Up.
+                //  if that happens, use the original input value
+                newValue = valueBeforeUpDown ? valueBeforeUpDown : value;
+              } else {
+                newValue = this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
+              }
 
               updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value);
               this.maybeCallOnChange(event, newValue, event.key === 'ArrowDown' ? 'down' : 'up');

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -164,7 +164,7 @@ class Autosuggest extends Component {
       let sectionIndex = multiSection ? 0 : null;
       let suggestionIndex = 0;
 
-      updateFocusedSuggestion(sectionIndex, suggestionIndex, value);
+      updateFocusedSuggestion(sectionIndex, suggestionIndex);
       this.maybeCallOnChange(event, value, 'auto');
     }
   }
@@ -192,7 +192,8 @@ class Autosuggest extends Component {
       getSectionSuggestions, focusInputOnSuggestionClick, theme, isFocused,
       isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
       valueBeforeUpDown, inputFocused, inputBlurred, inputChanged,
-      updateFocusedSuggestion, revealSuggestions, closeSuggestions
+      updateFocusedSuggestion, revealSuggestions, closeSuggestions,
+      getSuggestionValue
     } = this.props;
     const { value, onBlur, onFocus, onKeyDown } = inputProps;
     const isOpen = isFocused && !isCollapsed && this.willRenderSuggestions();
@@ -223,7 +224,7 @@ class Autosuggest extends Component {
         const { shouldRenderSuggestions } = this.props;
 
         this.maybeCallOnChange(event, value, 'type');
-        inputChanged(shouldRenderSuggestions(value), 'type', suggestions);
+        inputChanged(shouldRenderSuggestions(value), 'type');
         this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'type' });
         this.maybeSelectFirstSuggestion(event, value);
       },
@@ -237,8 +238,9 @@ class Autosuggest extends Component {
               }
             } else if (suggestions.length > 0) {
               const { newFocusedSectionIndex, newFocusedItemIndex } = data;
+              const safeValue = valueBeforeUpDown ? valueBeforeUpDown : value;
               const newValue = newFocusedItemIndex === null ?
-                valueBeforeUpDown :
+                safeValue :
                 this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
 
               updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value);
@@ -251,14 +253,18 @@ class Autosuggest extends Component {
             const focusedSuggestion = this.getFocusedSuggestion();
 
             if (focusedSuggestion !== null) {
+              const newValue = getSuggestionValue(focusedSuggestion);
+
               closeSuggestions('enter');
               onSuggestionSelected(event, {
                 suggestion: focusedSuggestion,
-                suggestionValue: value,
+                suggestionValue: newValue,
                 sectionIndex: focusedSectionIndex,
                 method: 'enter'
               });
-              this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'enter' });
+
+              this.maybeCallOnChange(event, newValue, event.key === 'enter');
+              this.maybeCallOnSuggestionsUpdateRequested({ value: newValue, reason: 'enter' });
             }
             break;
           }

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -51,6 +51,7 @@ class Autosuggest extends Component {
     renderSectionTitle: PropTypes.func.isRequired,
     getSectionSuggestions: PropTypes.func.isRequired,
     focusInputOnSuggestionClick: PropTypes.bool.isRequired,
+    selectFirstSuggestion: PropTypes.bool.isRequired,
     theme: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     inputRef: PropTypes.func.isRequired,
@@ -156,6 +157,18 @@ class Autosuggest extends Component {
     }
   }
 
+  maybeSelectFirstSuggestion(event, value) {
+    const { selectFirstSuggestion, multiSection, updateFocusedSuggestion } = this.props;
+
+    if (selectFirstSuggestion) {
+      let sectionIndex = multiSection ? 0 : null;
+      let suggestionIndex = 0;
+
+      updateFocusedSuggestion(sectionIndex, suggestionIndex, value);
+      this.maybeCallOnChange(event, value, 'auto');
+    }
+  }
+
   willRenderSuggestions() {
     const { suggestions, inputProps, shouldRenderSuggestions } = this.props;
     const { value } = inputProps;
@@ -189,6 +202,7 @@ class Autosuggest extends Component {
       onFocus: event => {
         if (!this.justClickedOnSuggestion) {
           inputFocused(shouldRenderSuggestions(value));
+          this.maybeSelectFirstSuggestion(event, value);
           onFocus && onFocus(event);
         }
       },
@@ -209,8 +223,9 @@ class Autosuggest extends Component {
         const { shouldRenderSuggestions } = this.props;
 
         this.maybeCallOnChange(event, value, 'type');
-        inputChanged(shouldRenderSuggestions(value), 'type');
+        inputChanged(shouldRenderSuggestions(value), 'type', suggestions);
         this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'type' });
+        this.maybeSelectFirstSuggestion(event, value);
       },
       onKeyDown: (event, data) => {
         switch (event.key) {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -165,7 +165,6 @@ class Autosuggest extends Component {
       let suggestionIndex = 0;
 
       updateFocusedSuggestion(sectionIndex, suggestionIndex);
-      this.maybeCallOnChange(event, value, 'auto');
     }
   }
 
@@ -252,7 +251,7 @@ class Autosuggest extends Component {
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 
-            if (focusedSuggestion) {
+            if (focusedSuggestion !== null) {
               const newValue = getSuggestionValue(focusedSuggestion);
 
               closeSuggestions('enter');

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -239,7 +239,7 @@ class Autosuggest extends Component {
               const { newFocusedSectionIndex, newFocusedItemIndex } = data;
 
               let newValue;
-              if(newFocusedItemIndex === null){
+              if (newFocusedItemIndex === null) {
                 // valueBeforeUpDown can be null if, for example, user
                 //  hovers on the first suggestion and then pressed Up.
                 //  if that happens, use the original input value
@@ -257,7 +257,7 @@ class Autosuggest extends Component {
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 
-            if (focusedSuggestion !== null) {
+            if (focusedSuggestion) {
               const newValue = getSuggestionValue(focusedSuggestion);
 
               closeSuggestions('enter');

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -202,7 +202,7 @@ class Autosuggest extends Component {
       onFocus: event => {
         if (!this.justClickedOnSuggestion) {
           inputFocused(shouldRenderSuggestions(value));
-          this.maybeSelectFirstSuggestion(event, value);
+          this.maybeSelectFirstSuggestion();
           onFocus && onFocus(event);
         }
       },
@@ -225,7 +225,7 @@ class Autosuggest extends Component {
         this.maybeCallOnChange(event, value, 'type');
         inputChanged(shouldRenderSuggestions(value), 'type');
         this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'type' });
-        this.maybeSelectFirstSuggestion(event, value);
+        this.maybeSelectFirstSuggestion();
       },
       onKeyDown: (event, data) => {
         switch (event.key) {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -268,7 +268,7 @@ class Autosuggest extends Component {
                 method: 'enter'
               });
 
-              this.maybeCallOnChange(event, newValue, event.key === 'enter');
+              this.maybeCallOnChange(event, newValue, 'enter');
               this.maybeCallOnSuggestionsUpdateRequested({ value: newValue, reason: 'enter' });
             }
             break;

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -252,7 +252,7 @@ class Autosuggest extends Component {
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 
-            if (focusedSuggestion !== null) {
+            if (focusedSuggestion) {
               const newValue = getSuggestionValue(focusedSuggestion);
 
               closeSuggestions('enter');

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -161,8 +161,8 @@ class Autosuggest extends Component {
     const { selectFirstSuggestion, multiSection, updateFocusedSuggestion } = this.props;
 
     if (selectFirstSuggestion) {
-      let sectionIndex = multiSection ? 0 : null;
-      let suggestionIndex = 0;
+      const sectionIndex = multiSection ? 0 : null;
+      const suggestionIndex = 0;
 
       updateFocusedSuggestion(sectionIndex, suggestionIndex);
     }

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -239,6 +239,7 @@ class Autosuggest extends Component {
               const { newFocusedSectionIndex, newFocusedItemIndex } = data;
 
               let newValue;
+
               if (newFocusedItemIndex === null) {
                 // valueBeforeUpDown can be null if, for example, user
                 //  hovers on the first suggestion and then pressed Up.

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -76,7 +76,7 @@ export default class AutosuggestContainer extends Component {
 
   static defaultProps = {
     onSuggestionsUpdateRequested: noop,
-    shouldRenderSuggestions: value => value && value.trim().length > 0,
+    shouldRenderSuggestions: value => value.trim().length > 0,
     onSuggestionSelected: noop,
     multiSection: false,
     renderSectionTitle() {

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -69,6 +69,7 @@ export default class AutosuggestContainer extends Component {
     renderSectionTitle: PropTypes.func,
     getSectionSuggestions: PropTypes.func,
     focusInputOnSuggestionClick: PropTypes.bool,
+    selectFirstSuggestion: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string
   };
@@ -85,6 +86,7 @@ export default class AutosuggestContainer extends Component {
       throw new Error('`getSectionSuggestions` must be provided');
     },
     focusInputOnSuggestionClick: true,
+    selectFirstSuggestion: false,
     theme: defaultTheme,
     id: '1'
   };
@@ -115,7 +117,8 @@ export default class AutosuggestContainer extends Component {
       multiSection, shouldRenderSuggestions, suggestions,
       onSuggestionsUpdateRequested, getSuggestionValue, renderSuggestion,
       renderSectionTitle, getSectionSuggestions, inputProps,
-      onSuggestionSelected, focusInputOnSuggestionClick, theme, id
+      onSuggestionSelected, focusInputOnSuggestionClick, selectFirstSuggestion,
+      theme, id
     } = this.props;
 
     return (
@@ -130,6 +133,7 @@ export default class AutosuggestContainer extends Component {
                    inputProps={inputProps}
                    onSuggestionSelected={onSuggestionSelected}
                    focusInputOnSuggestionClick={focusInputOnSuggestionClick}
+                   selectFirstSuggestion={selectFirstSuggestion}
                    theme={mapToAutowhateverTheme(theme)}
                    id={id}
                    inputRef={this.saveInput}

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -76,7 +76,7 @@ export default class AutosuggestContainer extends Component {
 
   static defaultProps = {
     onSuggestionsUpdateRequested: noop,
-    shouldRenderSuggestions: value => value.trim().length > 0,
+    shouldRenderSuggestions: value => value && value.trim().length > 0,
     onSuggestionSelected: noop,
     multiSection: false,
     renderSectionTitle() {

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -54,6 +54,18 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
   });
 });
 
+export const selectFirstSuggestion = {
+  value: false,
+
+  true() {
+    this.value = true;
+  },
+
+  false() {
+    this.value = false;
+  }
+};
+
 export default class AutosuggestApp extends Component {
   constructor() {
     super();
@@ -84,7 +96,8 @@ export default class AutosuggestApp extends Component {
                    renderSuggestion={renderSuggestion}
                    inputProps={inputProps}
                    shouldRenderSuggestions={shouldRenderSuggestions}
-                   onSuggestionSelected={onSuggestionSelected} />
+                   onSuggestionSelected={onSuggestionSelected}
+                   selectFirstSuggestion={selectFirstSuggestion.value} />
     );
   }
 }

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -54,9 +54,9 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
   });
 });
 
-let selectFirstSuggestionValue = false;
+let selectFirstSuggestion = false;
 export function setSelectFirstSuggestion(value){
-  selectFirstSuggestionValue = value;
+  selectFirstSuggestion = value;
 } 
 
 export default class AutosuggestApp extends Component {
@@ -90,7 +90,7 @@ export default class AutosuggestApp extends Component {
                    inputProps={inputProps}
                    shouldRenderSuggestions={shouldRenderSuggestions}
                    onSuggestionSelected={onSuggestionSelected}
-                   selectFirstSuggestion={selectFirstSuggestionValue} />
+                   selectFirstSuggestion={selectFirstSuggestion} />
     );
   }
 }

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -54,17 +54,10 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
   });
 });
 
-export const selectFirstSuggestion = {
-  value: false,
-
-  true() {
-    this.value = true;
-  },
-
-  false() {
-    this.value = false;
-  }
-};
+let selectFirstSuggestionValue = false;
+export function setSelectFirstSuggestion(value){
+  selectFirstSuggestionValue = value;
+} 
 
 export default class AutosuggestApp extends Component {
   constructor() {
@@ -97,7 +90,7 @@ export default class AutosuggestApp extends Component {
                    inputProps={inputProps}
                    shouldRenderSuggestions={shouldRenderSuggestions}
                    onSuggestionSelected={onSuggestionSelected}
-                   selectFirstSuggestion={selectFirstSuggestion.value} />
+                   selectFirstSuggestion={selectFirstSuggestionValue} />
     );
   }
 }

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -55,9 +55,10 @@ export const onSuggestionsUpdateRequested = sinon.spy(({ value }) => {
 });
 
 let selectFirstSuggestion = false;
-export function setSelectFirstSuggestion(value){
+
+export function setSelectFirstSuggestion(value) {
   selectFirstSuggestion = value;
-} 
+}
 
 export default class AutosuggestApp extends Component {
   constructor() {

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -203,6 +203,13 @@ describe('Plain list Autosuggest', () => {
       expectFocusedSuggestion('Python');
     });
 
+    it('should hide suggestions when pressing Enter after a mouse focuses a suggestion', () => {
+      mouseEnterSuggestion(2);
+      expectFocusedSuggestion('Python');
+      clickEnter();
+      expectSuggestions([]);
+    });
+
     it('should not have focused suggestions when mouse leaves a suggestion', () => {
       mouseEnterSuggestion(2);
       mouseLeaveSuggestion(2);

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -251,7 +251,7 @@ describe('Plain list Autosuggest', () => {
 
     it('should clear the input when Escape is pressed', () => {
       clickEscape();
-      expectInputValue('z');
+      expectInputValue('');
     });
   });
 
@@ -467,14 +467,14 @@ describe('Plain list Autosuggest', () => {
     it('should reset the input if suggestions are hidden and never been shown before', () => {
       focusAndSetInputValue('z');
       clickEscape();
-      expectInputValue('z');
+      expectInputValue('');
     });
 
     it('should reset the input if suggestions are hidden but were shown before', () => {
       focusAndSetInputValue('p');
       focusAndSetInputValue('pz');
       clickEscape();
-      expectInputValue('pz');
+      expectInputValue('');
     });
   });
 
@@ -528,11 +528,11 @@ describe('Plain list Autosuggest', () => {
     });
 
     beforeEach(() => {
-      getSuggestionValue.reset();
       focusAndSetInputValue('p');
+      getSuggestionValue.reset();
     });
 
-    it('should not be called once when Up is pressed (input is focused)', () => {
+    it('should not be called when Up is pressed (goes to input field)', () => {
       clickUp();
       expect(getSuggestionValue).not.to.have.been.called;
     });
@@ -544,9 +544,9 @@ describe('Plain list Autosuggest', () => {
     });
 
     it('should be called once with the right parameters when suggestion is clicked', () => {
-      clickSuggestion(0);
+      clickSuggestion(2);
       expect(getSuggestionValue).to.have.been.calledOnce;
-      expect(getSuggestionValue).to.have.been.calledWithExactly({ name: 'Perl', year: 1987 });
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ name: 'Python', year: 1991 });
     });
   });
 
@@ -685,7 +685,7 @@ describe('Plain list Autosuggest', () => {
       onChange.reset();
     });
 
-    it('should be called once with the right parameters when user types', () => {
+    it('should be called with the right parameters when user types', () => {
       focusAndSetInputValue('c');
       expect(onChange).to.have.been.calledTwice;
       expect(onChange).to.be.calledWith(eventInstance, {

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -181,7 +181,7 @@ describe('Plain list Autosuggest', () => {
       expectSuggestions(['Perl', 'PHP', 'Python']);
     });
 
-    it('should focus suggestion when input is focused again', () => {
+    it('should focus first suggestion when input is focused again', () => {
       blurInput();
       focusInput();
       expectFocusedSuggestion('Perl');

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -142,6 +142,7 @@ describe('Plain list Autosuggest', () => {
     });
 
     beforeEach(() => {
+      onSuggestionSelected.reset();
       focusAndSetInputValue('p');
     });
 
@@ -206,6 +207,24 @@ describe('Plain list Autosuggest', () => {
       mouseEnterSuggestion(2);
       mouseLeaveSuggestion(2);
       expectFocusedSuggestion(null);
+    });
+
+    it('should be called once with the right parameters when Enter is pressed', () => {
+      onChange.reset();
+      clickEnter();
+      expect(onSuggestionSelected).to.have.been.calledOnce;
+      expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
+        suggestion: { name: 'Perl', year: 1987 },
+        suggestionValue: 'Perl',
+        sectionIndex: null,
+        method: 'enter'
+      });
+
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWith(eventInstance, {
+        newValue: 'Perl',
+        method: 'enter'
+      });
     });
   });
 
@@ -781,6 +800,19 @@ describe('Plain list Autosuggest', () => {
         suggestionValue: 'Java',
         sectionIndex: null,
         method: 'enter'
+      });
+    });
+
+    it('should not call onChange when Enter is pressed and suggestion is focused with down since value did not change', () => {
+      onChange.reset();
+      clickDown();
+      clickEnter();
+
+      // onChange should not have been called because the value didn't change
+      expect(onChange).to.have.been.calledExactlyOnce;
+      expect(onChange).to.be.calledWithExactly(eventInstance, {
+        newValue: 'Java',
+        method: 'down'
       });
     });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -208,24 +208,6 @@ describe('Plain list Autosuggest', () => {
       mouseLeaveSuggestion(2);
       expectFocusedSuggestion(null);
     });
-
-    it('should be called once with the right parameters when Enter is pressed', () => {
-      onChange.reset();
-      clickEnter();
-      expect(onSuggestionSelected).to.have.been.calledOnce;
-      expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
-        suggestion: { name: 'Perl', year: 1987 },
-        suggestionValue: 'Perl',
-        sectionIndex: null,
-        method: 'enter'
-      });
-
-      expect(onChange).to.have.been.calledOnce;
-      expect(onChange).to.be.calledWith(eventInstance, {
-        newValue: 'Perl',
-        method: 'enter'
-      });
-    });
   });
 
   describe('when typing and matches do not exist', () => {
@@ -740,6 +722,8 @@ describe('Plain list Autosuggest', () => {
     });
 
     beforeEach(() => {
+      onSuggestionSelected.reset();
+      focusAndSetInputValue('p');
       onChange.reset();
     });
 
@@ -749,6 +733,23 @@ describe('Plain list Autosuggest', () => {
       expect(onChange).to.be.calledWith(eventInstance, {
         newValue: 'c',
         method: 'type'
+      });
+    });
+
+    it('should be called once with the right parameters when Enter is pressed', () => {
+      clickEnter();
+      expect(onSuggestionSelected).to.have.been.calledOnce;
+      expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
+        suggestion: { name: 'Perl', year: 1987 },
+        suggestionValue: 'Perl',
+        sectionIndex: null,
+        method: 'enter'
+      });
+
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWith(eventInstance, {
+        newValue: 'Perl',
+        method: 'enter'
       });
     });
   });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -228,7 +228,7 @@ describe('Plain list Autosuggest', () => {
     });
   });
 
-  describe('when typing and matches do not exist (when selectFirstSuggestion is true', () => {
+  describe('when typing and matches do not exist (when selectFirstSuggestion is true)', () => {
     before(() => {
       selectFirstSuggestion.true();
     });
@@ -252,6 +252,40 @@ describe('Plain list Autosuggest', () => {
     it('should clear the input when Escape is pressed', () => {
       clickEscape();
       expectInputValue('');
+    });
+  });
+
+  describe('when typing and matches exist, then mousing over first selection', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      mouseEnterSuggestion(0);
+    });
+
+    describe('when pressing up', () => {
+      beforeEach(() => {
+        clickUp();
+      });
+
+      it('should show the original input value', () => {
+        expectInputValue('p');
+      });
+    });
+  });
+
+  describe('when typing and matches exist, then mousing over last selection', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      mouseEnterSuggestion(2);
+    });
+
+    describe('when pressing down', () => {
+      beforeEach(() => {
+        clickDown();
+      });
+
+      it('should show the original input value', () => {
+        expectInputValue('p');
+      });
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -33,7 +33,7 @@ import AutosuggestApp, {
   shouldRenderSuggestions,
   onSuggestionSelected,
   onSuggestionsUpdateRequested,
-  selectFirstSuggestion
+  setSelectFirstSuggestion
 } from './AutosuggestApp';
 
 describe('Plain list Autosuggest', () => {
@@ -134,11 +134,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when typing and matches exist (when selectFirstSuggestion is true)', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -249,11 +249,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when typing and matches do not exist (when selectFirstSuggestion is true)', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -349,11 +349,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when pressing Down (when selectFirstSuggestion is true)', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -423,11 +423,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when pressing Up (when selectFirstSuggestion is true)', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -481,11 +481,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when pressing Enter and selectFirstSuggestion is true', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -515,11 +515,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('when pressing Escape and selectFirstSuggestion is true', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     it('should reset the input if suggestions are hidden and never been shown before', () => {
@@ -578,11 +578,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('getSuggestionValue when selectFirstSuggestion is true', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {
@@ -732,11 +732,11 @@ describe('Plain list Autosuggest', () => {
 
   describe('inputProps.onChange with selectFirstSuggestion', () => {
     before(() => {
-      selectFirstSuggestion.true();
+      setSelectFirstSuggestion(true);
     });
 
     after(() => {
-      selectFirstSuggestion.false();
+      setSelectFirstSuggestion(false);
     });
 
     beforeEach(() => {

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -716,6 +716,13 @@ describe('Plain list Autosuggest', () => {
       clickSuggestion(0);
       expect(onChange).not.to.have.been.called;
     });
+
+    it('should not call onChange for Enter event since value did not change', () => {
+      clickDown();
+      onChange.reset();
+      clickEnter();
+      expect(onChange).not.to.have.been.called;
+    });
   });
 
   describe('inputProps.onChange with selectFirstSuggestion', () => {
@@ -807,19 +814,6 @@ describe('Plain list Autosuggest', () => {
         suggestionValue: 'Java',
         sectionIndex: null,
         method: 'enter'
-      });
-    });
-
-    it('should not call onChange when Enter is pressed and suggestion is focused with down since value did not change', () => {
-      onChange.reset();
-      clickDown();
-      clickEnter();
-
-      // onChange should not have been called because the value didn't change
-      expect(onChange).to.have.been.calledExactlyOnce;
-      expect(onChange).to.be.calledWithExactly(eventInstance, {
-        newValue: 'Java',
-        method: 'down'
       });
     });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -32,7 +32,8 @@ import AutosuggestApp, {
   onBlur,
   shouldRenderSuggestions,
   onSuggestionSelected,
-  onSuggestionsUpdateRequested
+  onSuggestionsUpdateRequested,
+  selectFirstSuggestion
 } from './AutosuggestApp';
 
 describe('Plain list Autosuggest', () => {
@@ -131,6 +132,83 @@ describe('Plain list Autosuggest', () => {
     });
   });
 
+  describe('when typing and matches exist (when selectFirstSuggestion is true)', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+    });
+
+    it('should focus on any suggestion', () => {
+      expectFocusedSuggestion('Perl');
+    });
+
+    it('should hide suggestions when Escape is pressed', () => {
+      clickEscape();
+      expectSuggestions([]);
+    });
+
+    it('should hide suggestions when input is blurred', () => {
+      blurInput();
+      expectSuggestions([]);
+    });
+
+    it('should show suggestions', () => {
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+    });
+
+    it('should not clear the input when Escape is pressed', () => {
+      clickEscape();
+      expectInputValue('p');
+    });
+
+    it('should clear the input when Escape is pressed again', () => {
+      clickEscape();
+      clickEscape();
+      expectInputValue('');
+    });
+
+    it('should show suggestions when input is focused again', () => {
+      blurInput();
+      focusInput();
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+    });
+
+    it('should focus suggestion when input is focused again', () => {
+      blurInput();
+      focusInput();
+      expectFocusedSuggestion('Perl');
+    });
+
+    it('should revert input value when Escape is pressed after Up/Down interaction', () => {
+      clickDown();
+      clickEscape();
+      expectInputValue('p');
+    });
+
+    it('should update input value when suggestion is clicked', () => {
+      clickSuggestion(1);
+      expectInputValue('PHP');
+    });
+
+    it('should focus on suggestion when mouse enters it', () => {
+      mouseEnterSuggestion(2);
+      expectFocusedSuggestion('Python');
+    });
+
+    it('should not have focused suggestions when mouse leaves a suggestion', () => {
+      mouseEnterSuggestion(2);
+      mouseLeaveSuggestion(2);
+      expectFocusedSuggestion(null);
+    });
+  });
+
   describe('when typing and matches do not exist', () => {
     beforeEach(() => {
       focusAndSetInputValue('z');
@@ -140,13 +218,45 @@ describe('Plain list Autosuggest', () => {
       expectSuggestions([]);
     });
 
+    it('should not focus suggestions', () => {
+      expectFocusedSuggestion(null);
+    });
+
     it('should clear the input when Escape is pressed', () => {
       clickEscape();
       expectInputValue('');
     });
   });
 
+  describe('when typing and matches do not exist (when selectFirstSuggestion is true', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      focusAndSetInputValue('z');
+    });
+
+    it('should not show suggestions', () => {
+      expectSuggestions([]);
+    });
+
+    it('should not focus suggestions', () => {
+      expectFocusedSuggestion(null);
+    });
+
+    it('should clear the input when Escape is pressed', () => {
+      clickEscape();
+      expectInputValue('z');
+    });
+  });
+
   describe('when pressing Down', () => {
+
     beforeEach(() => {
       focusAndSetInputValue('p');
     });
@@ -175,6 +285,47 @@ describe('Plain list Autosuggest', () => {
 
     it('should focus on the first suggestion again', () => {
       clickDown(5);
+      expectFocusedSuggestion('Perl');
+    });
+  });
+
+  describe('when pressing Down (when selectFirstSuggestion is true)', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+    });
+
+    it('should show suggestions with no focused suggestion, if they are hidden', () => {
+      clickEscape();
+      clickDown();
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+      expectFocusedSuggestion(null);
+    });
+
+    it('should focus on the second suggestion (first was selected on input)', () => {
+      clickDown();
+      expectFocusedSuggestion('PHP');
+    });
+
+    it('should focus on the next suggestion', () => {
+      clickDown(2);
+      expectFocusedSuggestion('Python');
+    });
+
+    it('should not focus on any suggestion after reaching the last suggestion', () => {
+      clickDown(3);
+      expectFocusedSuggestion(null);
+    });
+
+    it('should focus on the first suggestion again', () => {
+      clickDown(4);
       expectFocusedSuggestion('Perl');
     });
   });
@@ -212,6 +363,47 @@ describe('Plain list Autosuggest', () => {
     });
   });
 
+  describe('when pressing Up (when selectFirstSuggestion is true)', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+    });
+
+    it('should show suggestions with no focused suggestion, if they are hidden', () => {
+      clickEscape();
+      clickUp();
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+      expectFocusedSuggestion(null);
+    });
+
+    it('should focus on the input field', () => {
+      clickUp();
+      expectFocusedSuggestion(null);
+    });
+
+    it('should focus on the last suggestion', () => {
+      clickUp(2);
+      expectFocusedSuggestion('Python');
+    });
+
+    it('should focus on the second to last suggestion', () => {
+      clickUp(3);
+      expectFocusedSuggestion('PHP');
+    });
+
+    it('should focus on the first suggestion again', () => {
+      clickUp(4);
+      expectFocusedSuggestion('Perl');
+    });
+  });
+
   describe('when pressing Enter', () => {
     beforeEach(() => {
       focusAndSetInputValue('p');
@@ -229,6 +421,25 @@ describe('Plain list Autosuggest', () => {
     });
   });
 
+  describe('when pressing Enter and selectFirstSuggestion is true', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+    });
+
+    it('should hide suggestions since the first suggestion is focused', () => {
+      clickEnter();
+      expectSuggestions([]);
+    });
+  });
+
   describe('when pressing Escape', () => {
     it('should clear the input if suggestions are hidden and never been shown before', () => {
       focusAndSetInputValue('z');
@@ -241,6 +452,29 @@ describe('Plain list Autosuggest', () => {
       focusAndSetInputValue('pz');
       clickEscape();
       expectInputValue('');
+    });
+  });
+
+  describe('when pressing Escape and selectFirstSuggestion is true', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    it('should reset the input if suggestions are hidden and never been shown before', () => {
+      focusAndSetInputValue('z');
+      clickEscape();
+      expectInputValue('z');
+    });
+
+    it('should reset the input if suggestions are hidden but were shown before', () => {
+      focusAndSetInputValue('p');
+      focusAndSetInputValue('pz');
+      clickEscape();
+      expectInputValue('pz');
     });
   });
 
@@ -281,6 +515,38 @@ describe('Plain list Autosuggest', () => {
       clickSuggestion(0);
       expect(getSuggestionValue).to.have.been.calledOnce;
       expect(getSuggestionValue).to.have.been.calledWithExactly({ name: 'Ruby', year: 1995 });
+    });
+  });
+
+  describe('getSuggestionValue when selectFirstSuggestion is true', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      getSuggestionValue.reset();
+      focusAndSetInputValue('p');
+    });
+
+    it('should not be called once when Up is pressed (input is focused)', () => {
+      clickUp();
+      expect(getSuggestionValue).not.to.have.been.called;
+    });
+
+    it('should be called once with the right parameters when Down is pressed', () => {
+      clickDown();
+      expect(getSuggestionValue).to.have.been.calledOnce;
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ name: 'PHP', year: 1995 });
+    });
+
+    it('should be called once with the right parameters when suggestion is clicked', () => {
+      clickSuggestion(0);
+      expect(getSuggestionValue).to.have.been.calledOnce;
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ name: 'Perl', year: 1987 });
     });
   });
 
@@ -403,6 +669,29 @@ describe('Plain list Autosuggest', () => {
       onChange.reset();
       clickSuggestion(0);
       expect(onChange).not.to.have.been.called;
+    });
+  });
+
+  describe('inputProps.onChange with selectFirstSuggestion', () => {
+    before(() => {
+      selectFirstSuggestion.true();
+    });
+
+    after(() => {
+      selectFirstSuggestion.false();
+    });
+
+    beforeEach(() => {
+      onChange.reset();
+    });
+
+    it('should be called once with the right parameters when user types', () => {
+      focusAndSetInputValue('c');
+      expect(onChange).to.have.been.calledTwice;
+      expect(onChange).to.be.calledWith(eventInstance, {
+        newValue: 'c',
+        method: 'auto'
+      });
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -253,6 +253,11 @@ describe('Plain list Autosuggest', () => {
       clickEscape();
       expectInputValue('');
     });
+
+    it('should not error when Enter is pressed', () => {
+      clickEnter();
+      expectInputValue('z');
+    });
   });
 
   describe('when typing and matches exist, then mousing over first selection', () => {

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -687,10 +687,10 @@ describe('Plain list Autosuggest', () => {
 
     it('should be called with the right parameters when user types', () => {
       focusAndSetInputValue('c');
-      expect(onChange).to.have.been.calledTwice;
+      expect(onChange).to.have.been.calledOnce;
       expect(onChange).to.be.calledWith(eventInstance, {
         newValue: 'c',
-        method: 'auto'
+        method: 'type'
       });
     });
   });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -146,7 +146,7 @@ describe('Plain list Autosuggest', () => {
       focusAndSetInputValue('p');
     });
 
-    it('should focus on any suggestion', () => {
+    it('should focus first suggestion', () => {
       expectFocusedSuggestion('Perl');
     });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -296,7 +296,6 @@ describe('Plain list Autosuggest', () => {
   });
 
   describe('when pressing Down', () => {
-
     beforeEach(() => {
       focusAndSetInputValue('p');
     });


### PR DESCRIPTION
## Overview

This PR adds a setting `selectFirstSuggestion` which, when true, automatically selects the first suggestion in the list. **Note:** this PR also fixes a bug where when you hover over an option and hit enter the selected item was not completed.

Closes https://github.com/moroshko/react-autosuggest/issues/147

## Details
- Adds a `selectFirstSuggestion` prop which defaults to `false`
- Adds a method `maybeSelectFirstSuggestion` which selects the first selection when applicable
- Calls the above method in `onChange` and `onFocus`
- Adds a call to `getSuggestionValue` on Enter events to ensure the value for the selected element is input.
- Adds a call to `maybeCallOnChange` on Enter events to ensure that clients get the onChange event (this is for instances where the element was hovered or auto-selected but the client never got an onChange event).
- Adds tests for all related functionality

## Screen

#### Selecting and entering first item

![](http://dp.hanlon.io/040a2y300N1t/Screen%20Recording%202016-05-05%20at%2008.38%20PM.gif)

#### Selecting and entering first item in multi-sections
![](http://dp.hanlon.io/0e1m3g3c0e3v/Screen%20Recording%202016-05-05%20at%2008.41%20PM.gif)

#### Bug fix - now selects on hover with enter:

![](http://dp.hanlon.io/3A0K2Z3r0V3r/Screen%20Recording%202016-05-05%20at%2008.42%20PM.gif)
