### PR TITLE
Blur input on touch devices when clicking on the rest of the page.

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -74,6 +74,12 @@ class Autosuggest extends Component {
     super();
 
     this.saveInput = this.saveInput.bind(this);
+    this.onDocumentTouchEnd = this.onDocumentTouchEnd.bind(this);
+  }
+
+  componentDidMount() {
+    this.touchingInput = false;
+    global.window.addEventListener('touchend', this.onDocumentTouchEnd, false);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -87,6 +93,17 @@ class Autosuggest extends Component {
         revealSuggestions();
       }
     }
+  }
+
+  componentWillUnmount() {
+    global.window.removeEventListener('touchend', this.onDocumentTouchEnd, false);
+  }
+
+  onDocumentTouchEnd() {
+    if (!this.touchingInput) {
+      this.input.blur();
+    }
+    this.touchingInput = false;
   }
 
   getSuggestion(sectionIndex, suggestionIndex) {
@@ -186,6 +203,7 @@ class Autosuggest extends Component {
     const items = (isOpen ? suggestions : []);
     const autowhateverInputProps = {
       ...inputProps,
+      onTouchStart: () => this.touchingInput = true,
       onFocus: event => {
         if (!this.justClickedOnSuggestion) {
           inputFocused(shouldRenderSuggestions(value));

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { inputFocused, inputBlurred, inputChanged, updateFocusedSuggestion,
          revealSuggestions, closeSuggestions } from './reducerAndActions';
@@ -42,8 +42,8 @@ function extractTouchCoordinates({ changedTouches }) {
   return { x: changedTouches[0].pageX, y: changedTouches[0].pageY };
 }
 
-const Autosuggest = React.createClass({
-  propTypes: {
+class Autosuggest extends Component {
+  static propTypes = {
     suggestions: PropTypes.array.isRequired,
     onSuggestionsUpdateRequested: PropTypes.func.isRequired,
     getSuggestionValue: PropTypes.func.isRequired,
@@ -72,19 +72,26 @@ const Autosuggest = React.createClass({
     updateFocusedSuggestion: PropTypes.func.isRequired,
     revealSuggestions: PropTypes.func.isRequired,
     closeSuggestions: PropTypes.func.isRequired
-  },
+  };
 
-  componentWillMount() {
+  constructor() {
+    super();
+
+    this.saveInput = this.saveInput.bind(this);
+    this.onDocumentTouchStart = this.onDocumentTouchStart.bind(this);
+    this.onDocumentTouchEnd = this.onDocumentTouchEnd.bind(this);
+    this.onDocumentMouseUp = this.onDocumentMouseUp.bind(this);
+
     this.justTouchedInput = false;
     this.touchStart = null;
     this.justClickedOnSuggestion = false;
-  },
+  }
 
   componentDidMount() {
     global.window.addEventListener('touchstart', this.onDocumentTouchStart, false);
     global.window.addEventListener('touchend', this.onDocumentTouchEnd, false);
     global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.suggestions !== this.props.suggestions) {
@@ -97,17 +104,17 @@ const Autosuggest = React.createClass({
         revealSuggestions();
       }
     }
-  },
+  }
 
   componentWillUnmount() {
     global.window.removeEventListener('touchstart', this.onDocumentTouchStart, false);
     global.window.removeEventListener('touchend', this.onDocumentTouchEnd, false);
     global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
-  },
+  }
 
   onDocumentTouchStart(event) {
     this.touchStart = this.touchStart || extractTouchCoordinates(event);
-  },
+  }
 
   onDocumentTouchEnd(event) {
     const { x, y } = extractTouchCoordinates(event);
@@ -124,11 +131,11 @@ const Autosuggest = React.createClass({
     this.justTouchedInput = false;
     this.touchStart = null;
     setTimeout(() => this.justClickedOnSuggestion = false);
-  },
+  }
 
   onDocumentMouseUp() {
     setTimeout(() => this.justClickedOnSuggestion = false);
-  },
+  }
 
   getSuggestion(sectionIndex, suggestionIndex) {
     const { suggestions, multiSection, getSectionSuggestions } = this.props;
@@ -138,7 +145,7 @@ const Autosuggest = React.createClass({
     }
 
     return suggestions[suggestionIndex];
-  },
+  }
 
   getFocusedSuggestion() {
     const { focusedSectionIndex, focusedSuggestionIndex } = this.props;
@@ -148,13 +155,13 @@ const Autosuggest = React.createClass({
     }
 
     return this.getSuggestion(focusedSectionIndex, focusedSuggestionIndex);
-  },
+  }
 
   getSuggestionValueByIndex(sectionIndex, suggestionIndex) {
     const { getSuggestionValue } = this.props;
 
     return getSuggestionValue(this.getSuggestion(sectionIndex, suggestionIndex));
-  },
+  }
 
   getSuggestionIndices(suggestionElement) {
     const sectionIndex = suggestionElement.getAttribute('data-section-index');
@@ -164,7 +171,7 @@ const Autosuggest = React.createClass({
       sectionIndex: (typeof sectionIndex === 'string' ? parseInt(sectionIndex, 10) : null),
       suggestionIndex: parseInt(suggestionIndex, 10)
     };
-  },
+  }
 
   findSuggestionElement(startNode) {
     let node = startNode;
@@ -179,7 +186,7 @@ const Autosuggest = React.createClass({
 
     console.error('Clicked element:', startNode); // eslint-disable-line no-console
     throw new Error('Couldn\'t find suggestion element');
-  },
+  }
 
   maybeCallOnChange(event, newValue, method) {
     const { value, onChange } = this.props.inputProps;
@@ -187,7 +194,7 @@ const Autosuggest = React.createClass({
     if (newValue !== value) {
       onChange && onChange(event, { newValue, method });
     }
-  },
+  }
 
   maybeCallOnSuggestionsUpdateRequested(data) {
     const { onSuggestionsUpdateRequested, shouldRenderSuggestions } = this.props;
@@ -195,14 +202,14 @@ const Autosuggest = React.createClass({
     if (shouldRenderSuggestions(data.value)) {
       onSuggestionsUpdateRequested(data);
     }
-  },
+  }
 
   willRenderSuggestions() {
     const { suggestions, inputProps, shouldRenderSuggestions } = this.props;
     const { value } = inputProps;
 
     return suggestions.length > 0 && shouldRenderSuggestions(value);
-  },
+  }
 
   saveInput(autowhatever) {
     if (autowhatever !== null) {
@@ -211,7 +218,7 @@ const Autosuggest = React.createClass({
       this.input = input;
       this.props.inputRef(input);
     }
-  },
+  }
 
   render() {
     const {
@@ -377,6 +384,6 @@ const Autosuggest = React.createClass({
                     ref={this.saveInput} />
     );
   }
-});
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(Autosuggest);

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { createStore } from 'redux';
 import reducer from './reducerAndActions';
 import Autosuggest from './Autosuggest';
@@ -46,8 +46,8 @@ function mapToAutowhateverTheme(theme) {
   return result;
 }
 
-export default class AutosuggestContainer extends Component {
-  static propTypes = {
+export default React.createClass({
+  propTypes: {
     suggestions: PropTypes.array.isRequired,
     onSuggestionsUpdateRequested: PropTypes.func,
     getSuggestionValue: PropTypes.func.isRequired,
@@ -71,27 +71,27 @@ export default class AutosuggestContainer extends Component {
     focusInputOnSuggestionClick: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string
-  };
+  },
 
-  static defaultProps = {
-    onSuggestionsUpdateRequested: noop,
-    shouldRenderSuggestions: value => value.trim().length > 0,
-    onSuggestionSelected: noop,
-    multiSection: false,
-    renderSectionTitle() {
-      throw new Error('`renderSectionTitle` must be provided');
-    },
-    getSectionSuggestions() {
-      throw new Error('`getSectionSuggestions` must be provided');
-    },
-    focusInputOnSuggestionClick: true,
-    theme: defaultTheme,
-    id: '1'
-  };
+  getDefaultProps() {
+    return {
+      onSuggestionsUpdateRequested: noop,
+      shouldRenderSuggestions: value => value.trim().length > 0,
+      onSuggestionSelected: noop,
+      multiSection: false,
+      renderSectionTitle() {
+        throw new Error('`renderSectionTitle` must be provided');
+      },
+      getSectionSuggestions() {
+        throw new Error('`getSectionSuggestions` must be provided');
+      },
+      focusInputOnSuggestionClick: true,
+      theme: defaultTheme,
+      id: '1'
+    };
+  },
 
-  constructor() {
-    super();
-
+  componentWillMount() {
     const initialState = {
       isFocused: false,
       isCollapsed: true,
@@ -102,13 +102,11 @@ export default class AutosuggestContainer extends Component {
     };
 
     this.store = createStore(reducer, initialState);
-
-    this.saveInput = this.saveInput.bind(this);
-  }
+  },
 
   saveInput(input) {
     this.input = input;
-  }
+  },
 
   render() {
     const {
@@ -136,4 +134,4 @@ export default class AutosuggestContainer extends Component {
                    store={this.store} />
     );
   }
-}
+});

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { createStore } from 'redux';
 import reducer from './reducerAndActions';
 import Autosuggest from './Autosuggest';
@@ -46,8 +46,8 @@ function mapToAutowhateverTheme(theme) {
   return result;
 }
 
-export default React.createClass({
-  propTypes: {
+export default class AutosuggestContainer extends Component {
+  static propTypes = {
     suggestions: PropTypes.array.isRequired,
     onSuggestionsUpdateRequested: PropTypes.func,
     getSuggestionValue: PropTypes.func.isRequired,
@@ -71,27 +71,27 @@ export default React.createClass({
     focusInputOnSuggestionClick: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      onSuggestionsUpdateRequested: noop,
-      shouldRenderSuggestions: value => value.trim().length > 0,
-      onSuggestionSelected: noop,
-      multiSection: false,
-      renderSectionTitle() {
-        throw new Error('`renderSectionTitle` must be provided');
-      },
-      getSectionSuggestions() {
-        throw new Error('`getSectionSuggestions` must be provided');
-      },
-      focusInputOnSuggestionClick: true,
-      theme: defaultTheme,
-      id: '1'
-    };
-  },
+  static defaultProps = {
+    onSuggestionsUpdateRequested: noop,
+    shouldRenderSuggestions: value => value.trim().length > 0,
+    onSuggestionSelected: noop,
+    multiSection: false,
+    renderSectionTitle() {
+      throw new Error('`renderSectionTitle` must be provided');
+    },
+    getSectionSuggestions() {
+      throw new Error('`getSectionSuggestions` must be provided');
+    },
+    focusInputOnSuggestionClick: true,
+    theme: defaultTheme,
+    id: '1'
+  };
 
-  componentWillMount() {
+  constructor() {
+    super();
+
     const initialState = {
       isFocused: false,
       isCollapsed: true,
@@ -102,11 +102,13 @@ export default React.createClass({
     };
 
     this.store = createStore(reducer, initialState);
-  },
+
+    this.saveInput = this.saveInput.bind(this);
+  }
 
   saveInput(input) {
     this.input = input;
-  },
+  }
 
   render() {
     const {
@@ -134,4 +136,4 @@ export default React.createClass({
                    store={this.store} />
     );
   }
-});
+}


### PR DESCRIPTION
### Before this change

On Safari (Mac OS), Chrome (Mac OS and android and Mac OS with touch device emulation):
- when the user clicks on the `<input>` element
  - then the `<input>` element is focused
- when the user clicks or taps outside the react-autosuggest component
  - then the `<input>` element loses focus

On Mobile Safari (iOS) and Chrome (iOS):
- when the user clicks on the `<input>` element
  - then the `<input>` element is focused
- when the user clicks or taps outside the react-autosuggest component
  - then the `<input>` element does **NOT** lose focus

The only way to cause it to loose focus was to click on another element that could receive focus or to press the 'minimise' button on the device's keyboard.
### After this change

On Safari (Mac OS), Chrome (Mac OS, android and iOS), Mobile Safari (iOS):
- when the user clicks on the `<input>` element
  - then the `<input>` element is focused
- when the user clicks or taps outside the react-autosuggest component
  - then the `<input>` element loses focus

This replicates the behaviour of the search box on http://google.com

Also fixed bug where the user tapped or clicked on a suggestion, then dragged outside the component meaning the `mouseup` or `touchend` event wasn't triggered on the suggestion, so the `justClickedSuggestion` flag was not reset.

I tried to create some tests for this, but failed to correctly trigger events on the document.
