### PR TITLE
Hiding autosuggest box when enter is hit and no suggestion is focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Check out the <a href="http://react-autosuggest.js.org" target="_blank">Homepage
 ## Installation
 
 ```shell
-npm install react-autosuggest --save
+npm install @jamiedixon/react-autosuggest --save
 ```
 
 ## Basic Usage
@@ -66,7 +66,7 @@ const languages = [
 function getSuggestions(value) {
   const inputValue = value.trim().toLowerCase();
   const inputLength = inputValue.length;
-  
+
   return inputLength === 0 ? [] : languages.filter(lang =>
     lang.name.toLowerCase().slice(0, inputLength) === inputValue
   );

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Check out the <a href="http://react-autosuggest.js.org" target="_blank">Homepage
 ## Installation
 
 ```shell
-npm install @jamiedixon/react-autosuggest --save
+npm install react-autosuggest --save
 ```
 
 ## Basic Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-autosuggest",
-  "version": "3.7.3",
+  "name": "@jamiedixon/react-autosuggest",
+  "version": "3.7.4",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jamiedixon/react-autosuggest",
-  "version": "3.7.4",
+  "name": "react-autosuggest",
+  "version": "3.7.3",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -235,8 +235,9 @@ class Autosuggest extends Component {
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 
+            closeSuggestions('enter');
+
             if (focusedSuggestion !== null) {
-              closeSuggestions('enter');
               onSuggestionSelected(event, {
                 suggestion: focusedSuggestion,
                 suggestionValue: value,

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -223,9 +223,9 @@ describe('Plain list Autosuggest', () => {
       expectSuggestions([]);
     });
 
-    it('should not hide suggestions if there is no focused suggestion', () => {
+    it('should hide suggestions if there is no focused suggestion', () => {
       clickEnter();
-      expectSuggestions(['Perl', 'PHP', 'Python']);
+      expectSuggestions([]);
     });
   });
 


### PR DESCRIPTION
This change hides the suggestions when the user hits enter. We use the autosuggest component within a form quite often and since suggestions are non-mandatory (since they're suggestions) we feel that the behaviour of entering a non-suggested term should be the same as picking one of the suggestions, in this case, hiding the suggestion box.

This PR relates to the discussion at: https://github.com/moroshko/react-autosuggest/issues/158

👍 

