### PR TITLE
Mimic Select element

### DIFF
--- a/demo/src/components/App/components/Examples/Examples.js
+++ b/demo/src/components/App/components/Examples/Examples.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Basic from 'Basic/Basic';
 import MultipleSections from 'MultipleSections/MultipleSections';
 import CustomRender from 'CustomRender/CustomRender';
+import Select from 'Select/Select';
 
 export default function Examples() {
   return (
@@ -14,6 +15,7 @@ export default function Examples() {
       <Basic />
       <MultipleSections />
       <CustomRender />
+      <Select />
     </div>
   );
 }

--- a/demo/src/components/App/components/Examples/components/Select/Select.js
+++ b/demo/src/components/App/components/Examples/components/Select/Select.js
@@ -1,0 +1,97 @@
+import styles from './Select.less';
+import theme from './theme.less';
+
+import React, { Component } from 'react';
+import Link from 'Link/Link';
+import Autosuggest from 'AutosuggestContainer';
+import options from './options';
+
+function identity(x) {
+  return x;
+}
+
+function always() {
+  return true;
+}
+
+function renderInput(inputProps) {
+  return (
+    <div {...inputProps}><span className={theme.arrow}>{inputProps.value.label}</span></div>
+  );
+}
+
+function renderSuggestion(suggestion, { value }) {
+  const highlight = suggestion === value;
+
+  return (
+    <span className={`${theme.option} ${highlight ? theme.optionHighlighted : ''}`}>
+      {highlight ? <span className={theme.icon} /> : null}
+      {suggestion.label}
+    </span>
+  );
+}
+
+export default class Select extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      value: options[0],
+      displayValue: null
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(event, { suggestion }) {
+    this.setState({
+      value: suggestion,
+      displayValue: null
+    });
+  }
+
+  render() {
+    const { value, displayValue } = this.state;
+    const inputProps = {
+      tabIndex: 0,
+      autoComplete: null,
+      type: null,
+      value: (displayValue || value),
+      onChange: (_, { newValue }) => this.setState({ displayValue: newValue }),
+      onBlur: () => this.setState({ displayValue: null })
+    };
+
+    return (
+      <div id="basic-example" className={styles.container}>
+        <div className={styles.textContainer}>
+          <div className={styles.title}>
+            Select List
+          </div>
+          <div className={styles.description}>
+            Can also mimic the behaviour of a select list, useful if you want to reuse styles for
+            select and autocomplete components.
+          </div>
+          <Link className={styles.codepenLink}
+                href="http://codepen.io/moroshko/pen/LGNJMy" underline={false}>
+            Codepen
+          </Link>
+        </div>
+        <div className={styles.autosuggest}>
+          Option:
+          <Autosuggest suggestions={options}
+                       wrapItemFocus={false}
+                       shouldRenderSuggestions={always}
+                       getSuggestionValue={identity}
+                       renderSuggestion={renderSuggestion}
+                       renderInput={renderInput}
+                       onSuggestionSelected={this.onChange}
+                       inputProps={inputProps}
+                       blurOnSuggestionSelect={true}
+                       focusInputOnSuggestionClick={false}
+                       theme={theme}
+                       id="select-example" />
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/src/components/App/components/Examples/components/Select/Select.js
+++ b/demo/src/components/App/components/Examples/components/Select/Select.js
@@ -79,13 +79,13 @@ export default class Select extends Component {
         <div className={styles.autosuggest}>
           Option:
           <Autosuggest suggestions={options}
-                       wrapItemFocus={false}
                        shouldRenderSuggestions={always}
                        getSuggestionValue={identity}
                        renderSuggestion={renderSuggestion}
                        renderInput={renderInput}
                        onSuggestionSelected={this.onChange}
                        inputProps={inputProps}
+                       wrapItemFocus={false}
                        blurOnSuggestionSelect={true}
                        focusInputOnSuggestionClick={false}
                        theme={theme}

--- a/demo/src/components/App/components/Examples/components/Select/Select.less
+++ b/demo/src/components/App/components/Examples/components/Select/Select.less
@@ -1,0 +1,55 @@
+@import '~variables';
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  width: 34 * @columns;
+  margin: (16 * @rows) (0.5 * @column) 0;
+
+  @media @examples-vertical {
+    flex-direction: column;
+    width: 14 * @columns;
+  }
+
+  @media @small {
+    margin-top: 12 * @rows;
+  }
+}
+
+.textContainer {
+  display: flex;
+  flex-direction: column;
+  width: 15 * @columns;
+}
+
+.title {
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 5 * @rows;
+
+  @media @small {
+    font-size: 25px;
+  }
+}
+
+.description {
+  margin-top: @row;
+  font-size: 20px;
+}
+
+.codepenLink {
+  margin-top: @row;
+  font-size: 20px;
+  color: #209FD3;
+}
+
+.autosuggest {
+  margin-top: 6 * @rows;
+
+  @media @examples-vertical {
+    margin-top: 3 * @rows;
+    margin-left: 0;
+  }
+}
+
+

--- a/demo/src/components/App/components/Examples/components/Select/options.js
+++ b/demo/src/components/App/components/Examples/components/Select/options.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    label: 'None',
+    value: 0
+  },
+  {
+    label: 'One',
+    value: 1
+  },
+  {
+    label: 'Few',
+    value: 3
+  },
+  {
+    label: 'Lots',
+    value: 20
+  }
+];

--- a/demo/src/components/App/components/Examples/components/Select/theme.less
+++ b/demo/src/components/App/components/Examples/components/Select/theme.less
@@ -1,0 +1,108 @@
+@font-size: 16px;
+@border-color: #aaa;
+@border-radius: 4px;
+
+.container {
+  display: inline-block;
+  position: relative;
+}
+
+.input {
+  font-size: 1em;
+  border: none;
+  cursor: pointer;
+  color: #009EDC;
+  width: 6em;
+  transition: color 200ms;
+  margin-left: 1em;
+  position: relative;
+  display: inline-block;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.arrow:after {
+  content: ' ';
+  position: absolute;
+  border-bottom: 2px solid #002b3c;
+  border-right: 2px solid #002b3c;
+  width: .6em;
+  height: .6em;
+  top: 0.1em;
+  margin-left: .5em;
+  opacity: 0;
+  transform: rotate(45deg);
+}
+
+.input:hover,
+.input[aria-expanded="true"] {
+  color: #002b3c;
+  .arrow:after {
+    transition: opacity 200ms;
+    opacity: 1;
+  }
+}
+
+.suggestionsContainer {
+  position: absolute;
+  top: 1em;
+  left: -0.4em;
+  margin: 1.4em 0 0 0;
+  min-width: 6rem;
+  padding: 0;
+  list-style-type: none;
+  border: 1px solid #cbcedb;
+  background-color: #fff;
+  border-radius: 0.3em;
+  z-index: 2;
+  color: #009EDC;
+}
+
+.suggestionsContainer:before {
+  content: ' ';
+  position: absolute;
+  border-top: 1px solid #cbcedb;
+  border-right: 1px solid #cbcedb;
+  background: #fff;
+  width: .7em;
+  height: .7em;
+  top: -.4em;
+  left: 2em;
+  transform: scale(1, 1.2) rotate(-45deg);
+}
+
+.option {
+  display: block;
+  position: relative;
+  cursor: pointer;
+  padding: 1em 2.2em 1em 1.4em;
+  white-space: nowrap;
+  transition: color 200ms, padding 200ms;
+}
+
+.optionHighlighted {
+  padding-left: 2.2em;
+  padding-right: 1.4em;
+  cursor: default;
+  color: #0C7EAF;
+}
+
+.icon {
+  background: #0C7EAF;
+  width: .5em;
+  height: .5em;
+  position: absolute;
+  top: 1.4em;
+  left: 1.4em;
+  border-radius: 50%;
+}
+
+.suggestion:not(:first-child) {
+  border-top: 1px dotted #cbcedb;
+}
+
+.suggestionFocused {
+  color: #000;
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublish": "npm run dist && npm run standalone"
   },
   "dependencies": {
-    "react-autowhatever": "^3.3.0",
+    "react-autowhatever": "git://github.com/packetloop/react-autowhatever#dist",
     "react-redux": "^4.4.5",
     "redux": "^3.5.1"
   },

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -44,6 +44,7 @@ class Autosuggest extends Component {
     onSuggestionsUpdateRequested: PropTypes.func.isRequired,
     getSuggestionValue: PropTypes.func.isRequired,
     renderSuggestion: PropTypes.func.isRequired,
+    renderInput: PropTypes.func,
     inputProps: PropTypes.object.isRequired,
     shouldRenderSuggestions: PropTypes.func.isRequired,
     onSuggestionSelected: PropTypes.func.isRequired,
@@ -51,6 +52,7 @@ class Autosuggest extends Component {
     renderSectionTitle: PropTypes.func.isRequired,
     getSectionSuggestions: PropTypes.func.isRequired,
     focusInputOnSuggestionClick: PropTypes.bool.isRequired,
+    blurOnSuggestionSelect: PropTypes.bool.isRequired,
     theme: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     inputRef: PropTypes.func.isRequired,
@@ -59,7 +61,11 @@ class Autosuggest extends Component {
     isCollapsed: PropTypes.bool.isRequired,
     focusedSectionIndex: PropTypes.number,
     focusedSuggestionIndex: PropTypes.number,
-    valueBeforeUpDown: PropTypes.string,
+    wrapItemFocus: PropTypes.bool,
+    valueBeforeUpDown: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     lastAction: PropTypes.string,
 
     inputFocused: PropTypes.func.isRequired,
@@ -179,7 +185,8 @@ class Autosuggest extends Component {
       getSectionSuggestions, focusInputOnSuggestionClick, theme, isFocused,
       isCollapsed, focusedSectionIndex, focusedSuggestionIndex,
       valueBeforeUpDown, inputFocused, inputBlurred, inputChanged,
-      updateFocusedSuggestion, revealSuggestions, closeSuggestions
+      updateFocusedSuggestion, revealSuggestions, closeSuggestions,
+      renderInput, wrapItemFocus, blurOnSuggestionSelect
     } = this.props;
     const { value, onBlur, onFocus, onKeyDown } = inputProps;
     const isOpen = isFocused && !isCollapsed && this.willRenderSuggestions();
@@ -246,6 +253,9 @@ class Autosuggest extends Component {
               });
               this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'enter' });
             }
+            if (blurOnSuggestionSelect) {
+              this.input.blur();
+            }
             break;
           }
 
@@ -268,6 +278,10 @@ class Autosuggest extends Component {
             }
 
             closeSuggestions('escape');
+
+            if (blurOnSuggestionSelect) {
+              this.input.blur();
+            }
             break;
         }
 
@@ -328,10 +342,12 @@ class Autosuggest extends Component {
       <Autowhatever multiSection={multiSection}
                     items={items}
                     renderItem={renderItem}
+                    renderInput={renderInput}
                     renderSectionTitle={renderSectionTitle}
                     getSectionItems={getSectionSuggestions}
                     focusedSectionIndex={focusedSectionIndex}
                     focusedItemIndex={focusedSuggestionIndex}
+                    wrapItemFocus={wrapItemFocus}
                     inputProps={autowhateverInputProps}
                     itemProps={itemProps}
                     theme={theme}

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -52,6 +52,7 @@ export default class AutosuggestContainer extends Component {
     onSuggestionsUpdateRequested: PropTypes.func,
     getSuggestionValue: PropTypes.func.isRequired,
     renderSuggestion: PropTypes.func.isRequired,
+    renderInput: PropTypes.func,
     inputProps: (props, propName) => {
       const inputProps = props[propName];
 
@@ -69,6 +70,8 @@ export default class AutosuggestContainer extends Component {
     renderSectionTitle: PropTypes.func,
     getSectionSuggestions: PropTypes.func,
     focusInputOnSuggestionClick: PropTypes.bool,
+    blurOnSuggestionSelect: PropTypes.bool,
+    wrapItemFocus: PropTypes.bool,
     theme: PropTypes.object,
     id: PropTypes.string
   };
@@ -85,6 +88,8 @@ export default class AutosuggestContainer extends Component {
       throw new Error('`getSectionSuggestions` must be provided');
     },
     focusInputOnSuggestionClick: true,
+    blurOnSuggestionSelect: false,
+    wrapItemFocus: true,
     theme: defaultTheme,
     id: '1'
   };
@@ -115,7 +120,8 @@ export default class AutosuggestContainer extends Component {
       multiSection, shouldRenderSuggestions, suggestions,
       onSuggestionsUpdateRequested, getSuggestionValue, renderSuggestion,
       renderSectionTitle, getSectionSuggestions, inputProps,
-      onSuggestionSelected, focusInputOnSuggestionClick, theme, id
+      onSuggestionSelected, focusInputOnSuggestionClick, theme, id,
+      renderInput, wrapItemFocus, blurOnSuggestionSelect
     } = this.props;
 
     return (
@@ -125,11 +131,14 @@ export default class AutosuggestContainer extends Component {
                    onSuggestionsUpdateRequested={onSuggestionsUpdateRequested}
                    getSuggestionValue={getSuggestionValue}
                    renderSuggestion={renderSuggestion}
+                   renderInput={renderInput}
                    renderSectionTitle={renderSectionTitle}
                    getSectionSuggestions={getSectionSuggestions}
                    inputProps={inputProps}
                    onSuggestionSelected={onSuggestionSelected}
                    focusInputOnSuggestionClick={focusInputOnSuggestionClick}
+                   blurOnSuggestionSelect={blurOnSuggestionSelect}
+                   wrapItemFocus={wrapItemFocus}
                    theme={mapToAutowhateverTheme(theme)}
                    id={id}
                    inputRef={this.saveInput}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -54,6 +54,10 @@ export function expectInputValue(expectedValue) {
   expect(data.input.value).to.equal(expectedValue);
 }
 
+export function expectInputHTML(expectedValue) {
+  expect(getInnerHTML(data.input)).to.equal(expectedValue);
+}
+
 export function getSuggestionsContainer() {
   return TestUtils.findRenderedDOMComponentWithClass(data.app, 'react-autosuggest__suggestions-container');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,3 +8,4 @@ global.navigator = global.window.navigator;
 // the file, and the globals above need to be defined before React is required.
 require('./plain-list/AutosuggestApp.test');
 require('./multi-section/AutosuggestApp.test');
+require('./select/AutosuggestApp.test');

--- a/test/select/AutosuggestApp.js
+++ b/test/select/AutosuggestApp.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autosuggest from '../../src/AutosuggestContainer';
+import options from './options';
+import { addEvent } from '../helpers';
+
+let app = null;
+
+export const getSuggestionValue = sinon.spy(suggestion => suggestion);
+
+export const renderSuggestion = sinon.spy((suggestion, { value }) =>
+  suggestion === value ? <div>{suggestion.label}</div> : <span>{suggestion.label}</span>
+);
+
+export const renderInput = sinon.spy((inputProps) => <div {...inputProps}>{inputProps.value.label}</div>);
+
+export const onChange = sinon.spy((event, { newValue }) => {
+  addEvent('onChange');
+
+  app.setState({
+    displayValue: newValue
+  });
+});
+
+export const onBlur = sinon.spy(() => app.setState({ displayValue: null }));
+
+export const onSuggestionSelected = sinon.spy((event, { suggestion }) => {
+  addEvent('onSuggestionSelected');
+
+  app.setState({
+    value: suggestion,
+    displayValue: null
+  });
+});
+
+export const shouldRenderSuggestions = sinon.spy(() => true);
+
+export default class AutosuggestApp extends Component {
+  constructor() {
+    super();
+
+    app = this;
+
+    this.state = {
+      value: options[0],
+      displayValue: null
+    };
+  }
+
+  render() {
+    const { value, displayValue } = this.state;
+    const inputProps = {
+      id: 'my-awesome-autosuggest',
+      tabIndex: 0,
+      autoComplete: null,
+      type: null,
+      value: (displayValue || value),
+      onChange,
+      onBlur
+    };
+
+    return (
+      <Autosuggest suggestions={options}
+                   shouldRenderSuggestions={shouldRenderSuggestions}
+                   getSuggestionValue={getSuggestionValue}
+                   renderSuggestion={renderSuggestion}
+                   renderInput={renderInput}
+                   onSuggestionSelected={onSuggestionSelected}
+                   inputProps={inputProps}
+                   wrapItemFocus={false}
+                   blurOnSuggestionSelect={true}
+                   focusInputOnSuggestionClick={false} />
+    );
+  }
+}

--- a/test/select/AutosuggestApp.test.js
+++ b/test/select/AutosuggestApp.test.js
@@ -1,0 +1,462 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  eventInstance,
+  getInnerHTML,
+  expectInputAttribute,
+  expectInputHTML,
+  getSuggestionsContainer,
+  getSuggestion,
+  expectSuggestions,
+  expectFocusedSuggestion,
+  mouseEnterSuggestion,
+  mouseLeaveSuggestion,
+  clickSuggestion,
+  focusInput,
+  blurInput,
+  clickEscape,
+  clickEnter,
+  clickDown,
+  clickUp,
+  isInputFocused,
+  clearEvents,
+  getEvents
+} from '../helpers';
+import AutosuggestApp, {
+  getSuggestionValue,
+  renderSuggestion,
+  renderInput,
+  onChange,
+  onBlur,
+  shouldRenderSuggestions,
+  onSuggestionSelected
+} from './AutosuggestApp';
+
+const all = ['None', 'One', 'Few', 'Lots'];
+
+describe('Select Autosuggest', () => {
+  beforeEach(() => {
+    const app = TestUtils.renderIntoDocument(React.createElement(AutosuggestApp));
+    const container = TestUtils.findRenderedDOMComponentWithClass(app, 'react-autosuggest__container');
+    const input = TestUtils.findRenderedDOMComponentWithClass(app, 'react-autosuggest__input');
+
+    init({ app, container, input });
+  });
+
+  describe('initially', () => {
+    describe('should render an input and set its:', () => {
+      it('id', () => {
+        expectInputAttribute('id', 'my-awesome-autosuggest');
+      });
+
+      it('type', () => {
+        expectInputAttribute('type', null);
+      });
+
+      it('value', () => {
+        expectInputHTML('None');
+      });
+    });
+
+    it('should not show suggestions', () => {
+      expectSuggestions([]);
+    });
+  });
+
+  describe('focus should show suggestions', () => {
+    beforeEach(() => {
+      focusInput();
+    });
+
+    it('should show suggestions', () => {
+      expectSuggestions(all);
+    });
+
+    it('should not focus on any suggestion', () => {
+      expectFocusedSuggestion(null);
+    });
+
+    it('should hide suggestions when Escape is pressed', () => {
+      clickEscape();
+      expectSuggestions([]);
+    });
+
+    it('should not clear the input when Escape is pressed', () => {
+      clickEscape();
+      expectInputHTML('None');
+    });
+
+    it('should not clear the input when Escape is pressed again', () => {
+      clickEscape();
+      clickEscape();
+      expectInputHTML('None');
+    });
+
+    it('should hide suggestions when input is blurred', () => {
+      blurInput();
+      expectSuggestions([]);
+    });
+
+    it('should show suggestions when input is focused again', () => {
+      blurInput();
+      focusInput();
+      expectSuggestions(all);
+    });
+
+    it('should revert input value when Escape is pressed after Up/Down interaction', () => {
+      clickDown();
+      clickEscape();
+      expectInputHTML('None');
+    });
+
+    it('should update input value when suggestion is clicked', () => {
+      clickSuggestion(1);
+      expectInputHTML('One');
+    });
+
+    it('should focus on suggestion when mouse enters it', () => {
+      mouseEnterSuggestion(2);
+      expectFocusedSuggestion('Few');
+    });
+
+    it('should not have focused suggestions when mouse leaves a suggestion', () => {
+      mouseEnterSuggestion(2);
+      mouseLeaveSuggestion(2);
+      expectFocusedSuggestion(null);
+    });
+  });
+
+  describe('when pressing Down', () => {
+    beforeEach(() => {
+      focusInput();
+    });
+
+    it('should focus on the first suggestion', () => {
+      clickDown();
+      expectFocusedSuggestion('None');
+    });
+
+    it('should focus on the next suggestion', () => {
+      clickDown(2);
+      expectFocusedSuggestion('One');
+    });
+
+    it('should continue to focus on the last suggestion after reaching the end', () => {
+      clickDown(6);
+      expectFocusedSuggestion('Lots');
+    });
+  });
+
+  describe('when pressing Up', () => {
+    beforeEach(() => {
+      focusInput();
+    });
+
+    it('should focus on the last suggestion', () => {
+      clickUp();
+      expectFocusedSuggestion('Lots');
+    });
+
+    it('should focus on the second last suggestion', () => {
+      clickUp(2);
+      expectFocusedSuggestion('Few');
+    });
+
+    it('should continue to focus on the first suggestion after reaching the start', () => {
+      clickUp(6);
+      expectFocusedSuggestion('None');
+    });
+  });
+
+  describe('when pressing Enter', () => {
+    beforeEach(() => {
+      focusInput();
+    });
+
+    it('should hide suggestions if there is a focused suggestion', () => {
+      clickDown(2);
+      clickEnter();
+      expectSuggestions([]);
+    });
+
+    it('should blur if there is a focused suggestion', () => {
+      clickDown(2);
+      clickEnter();
+      expect(isInputFocused()).to.equal(false);
+    });
+
+    it('should set input value if there is a focused suggestion', () => {
+      clickDown(2);
+      clickEnter();
+      expectInputHTML('One');
+    });
+
+    // not sure why this is failing - suggestions are not present in the browser when I do manual testing
+    it.skip('should hide suggestions if there is no focused suggestion', () => {
+      clickEnter();
+      expectSuggestions([]);
+    });
+
+    it('should blur if there is no focused suggestion', () => {
+      clickEnter();
+      expect(isInputFocused()).to.equal(false);
+    });
+  });
+
+  describe('when pressing Escape', () => {
+    beforeEach(() => {
+      focusInput();
+    });
+
+    it('should loose focus', () => {
+      clickEscape();
+      expect(isInputFocused()).to.equal(false);
+    });
+
+    it('should hide suggestions', () => {
+      clickEscape();
+      expectSuggestions([]);
+    });
+
+    it('should revert to original value if focused value', () => {
+      clickDown(3);
+      clickEscape();
+      expectInputHTML('None');
+    });
+  });
+
+  describe('when suggestion is clicked', () => {
+    beforeEach(() => {
+      focusInput();
+      clickSuggestion(1);
+    });
+
+    it('set the input value', () => {
+      expectInputHTML('One');
+    });
+
+    it('should hide suggestions', () => {
+      expectSuggestions([]);
+    });
+
+    it('should not focus on input if focusInputOnSuggestionClick is false', () => {
+      expect(isInputFocused()).to.equal(false);
+    });
+  });
+
+  describe('when current value is clicked', () => {
+    beforeEach(() => {
+      focusInput();
+      clickSuggestion(0);
+    });
+
+    it('set the input value', () => {
+      expectInputHTML('None');
+    });
+
+    it('should hide suggestions', () => {
+      expectSuggestions([]);
+    });
+
+    it('should not focus on input if focusInputOnSuggestionClick is false', () => {
+      expect(isInputFocused()).to.equal(false);
+    });
+  });
+
+  describe('getSuggestionValue', () => {
+    beforeEach(() => {
+      getSuggestionValue.reset();
+      focusInput();
+    });
+
+    it('should be called once with the right parameters when Up is pressed', () => {
+      clickUp();
+      expect(getSuggestionValue).to.have.been.calledOnce;
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ label: 'Lots', value: 20 });
+    });
+
+    it('should be called once with the right parameters when Down is pressed', () => {
+      clickDown();
+      expect(getSuggestionValue).to.have.been.calledOnce;
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ label: 'None', value: 0 });
+    });
+
+    it('should be called once with the right parameters when suggestion is clicked', () => {
+      clickSuggestion(0);
+      expect(getSuggestionValue).to.have.been.calledOnce;
+      expect(getSuggestionValue).to.have.been.calledWithExactly({ label: 'None', value: 0 });
+    });
+  });
+
+  describe('renderSuggestion', () => {
+    beforeEach(() => {
+      renderSuggestion.reset();
+      focusInput();
+    });
+
+    it('should be called with the right parameters', () => {
+      const none = { label: 'None', value: 0 };
+      const one = { label: 'One', value: 1 };
+
+      renderSuggestion.reset();
+      clickDown();
+      expect(renderSuggestion).to.have.been.calledWithExactly(none, { value: none, valueBeforeUpDown: none });
+      renderSuggestion.reset();
+      clickDown();
+      expect(renderSuggestion).to.have.been.calledWithExactly(one, { value: one, valueBeforeUpDown: none });
+    });
+
+    it('should be called once per suggestion', () => {
+      expect(renderSuggestion).to.have.callCount(4);
+    });
+
+    it('return value should be used to render the selected suggestion differently', () => {
+      const selectedSuggestion = getSuggestion(0);
+      const secondSuggestion = getSuggestion(1);
+
+      expect(getInnerHTML(selectedSuggestion)).to.equal('<div>None</div>');
+      expect(getInnerHTML(secondSuggestion)).to.equal('<span>One</span>');
+    });
+  });
+
+  describe('renderInput', () => {
+    beforeEach(() => {
+      focusInput();
+      renderInput.reset();
+    });
+
+    it('should be called with the right parameters', () => {
+      clickDown();
+      expect(renderInput).to.have.been.calledOnce;
+      renderInput.reset();
+      clickDown();
+      expect(renderInput).to.have.been.calledOnce;
+    });
+  });
+
+  describe('inputProps.onChange', () => {
+    beforeEach(() => {
+      focusInput();
+      onChange.reset();
+    });
+
+    it('should be called once with the right parameters when pressing Down focuses on a suggestion which differs from input value', () => {
+      clickDown(2);
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWithExactly(eventInstance, {
+        newValue: { label: 'One', value: 1 },
+        method: 'down'
+      });
+    });
+
+    it('should be called once with the right parameters when pressing Up focuses on a suggestion which differs from input value', () => {
+      clickUp();
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWithExactly(eventInstance, {
+        newValue: { label: 'Lots', value: 20 },
+        method: 'up'
+      });
+    });
+
+    it('should be called once with the right parameters when suggestion which differs from input value is clicked', () => {
+      clickSuggestion(2);
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWithExactly(eventInstance, {
+        newValue: { label: 'Few', value: 3 },
+        method: 'click'
+      });
+    });
+
+    it('should not be called when pressing Down focuses on suggestion which value equals to input value', () => {
+      clickUp();
+      onChange.reset();
+      clickDown();
+      expect(onChange).not.to.have.been.called;
+    });
+
+    it('should not be called when pressing Up focuses on suggestion which value equals to input value', () => {
+      clickDown();
+      onChange.reset();
+      clickUp();
+      expect(onChange).not.to.have.been.called;
+    });
+
+    it('should not be called when Escape is pressed and suggestions are shown', () => {
+      clickEscape();
+      expect(onChange).not.to.have.been.called;
+    });
+
+    it('should not be called when suggestion which value equals to input value is clicked', () => {
+      clickSuggestion(0);
+      expect(onChange).not.to.have.been.called;
+    });
+  });
+
+  describe('onSuggestionSelected', () => {
+    beforeEach(() => {
+      onSuggestionSelected.reset();
+      focusInput();
+    });
+
+    it('should be called once with the right parameters when suggestion is clicked', () => {
+      clickSuggestion(1);
+      expect(onSuggestionSelected).to.have.been.calledOnce;
+      expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
+        suggestion: { label: 'One', value: 1 },
+        suggestionValue: { label: 'One', value: 1 },
+        sectionIndex: null,
+        method: 'click'
+      });
+    });
+
+    it('should be called once with the right parameters when Enter is pressed and suggestion is focused', () => {
+      clickDown();
+      clickDown();
+      clickEnter();
+      expect(onSuggestionSelected).to.have.been.calledOnce;
+      expect(onSuggestionSelected).to.have.been.calledWithExactly(eventInstance, {
+        suggestion: { label: 'One', value: 1 },
+        suggestionValue: { label: 'One', value: 1 },
+        sectionIndex: null,
+        method: 'enter'
+      });
+    });
+
+    it('should not be called when Enter is pressed and there is no focused suggestion', () => {
+      clickEnter();
+      expect(onSuggestionSelected).not.to.have.been.called;
+    });
+
+    it('should be called after inputProps.onChange when suggestion is clicked', () => {
+      onChange.reset();
+      clearEvents();
+      clickSuggestion(1);
+      expect(getEvents()).to.deep.equal(['onChange', 'onSuggestionSelected']);
+    });
+  });
+
+  describe('when blurOnSuggestionSelect is true', () => {
+    beforeEach(() => {
+      onBlur.reset();
+      focusInput();
+    });
+
+    it('should lose the focus on input when suggestion is clicked', () => {
+      clickSuggestion(1);
+      expect(isInputFocused()).to.equal(false);
+    });
+
+    it('should not call onBlur when suggestion is clicked', () => {
+      clickSuggestion(1);
+      expect(onBlur).to.have.been.called;
+    });
+
+    it('should call onBlur once with the right parameters when input is blurred', () => {
+      blurInput();
+      expect(onBlur).to.have.been.calledOnce;
+      expect(onBlur).to.have.been.calledWithExactly(eventInstance);
+    });
+  });
+});

--- a/test/select/options.js
+++ b/test/select/options.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    label: 'None',
+    value: 0
+  },
+  {
+    label: 'One',
+    value: 1
+  },
+  {
+    label: 'Few',
+    value: 3
+  },
+  {
+    label: 'Lots',
+    value: 20
+  }
+];


### PR DESCRIPTION
Depends on 
- https://github.com/moroshko/react-autowhatever/pull/10
- https://github.com/moroshko/section-iterator/pull/2

### TODO
- [ ] Confirm the correct aria attributes.
- [ ] Document how to create a valid `renderInput` function.

### Changes:

Added following props
```
renderInput: PropTypes.func // custom function to render input element passed to react-autowhatever
blurOnSuggestionSelect: PropTypes.bool.isRequired, // should the input always be blured when a suggestion is selected
wrapItemFocus: PropTypes.bool,  // option passed through to section-iterator
```
Changed `valueBeforeUpDown` from `string` to `string` or `object`.

If `props.blurOnSuggestionSelect` is set, then the input element is blurred when the user presses `Enter` or `Escape`.

Please see `demo/src/components/App/components/Examples/components/Select` 

