### PR TITLE
Correctly reset `justClickedOnSuggestion` on document mouseup/touchend

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -74,6 +74,12 @@ class Autosuggest extends Component {
     super();
 
     this.saveInput = this.saveInput.bind(this);
+    this.onDocumentMouseUp = this.onDocumentMouseUp.bind(this);
+  }
+
+  componentDidMount() {
+    global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.window.addEventListener('touchend', this.onDocumentMouseUp, false);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -87,6 +93,17 @@ class Autosuggest extends Component {
         revealSuggestions();
       }
     }
+  }
+
+  componentWillUnmount() {
+    global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.window.removeEventListener('touchend', this.onDocumentMouseUp, false);
+  }
+
+  onDocumentMouseUp() {
+    setTimeout(() => {
+      this.justClickedOnSuggestion = false;
+    });
   }
 
   getSuggestion(sectionIndex, suggestionIndex) {
@@ -306,10 +323,6 @@ class Autosuggest extends Component {
       }
 
       this.maybeCallOnSuggestionsUpdateRequested({ value: clickedSuggestionValue, reason: 'click' });
-
-      setTimeout(() => {
-        this.justClickedOnSuggestion = false;
-      });
     };
     const itemProps = ({ sectionIndex, itemIndex }) => {
       return {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -78,8 +78,8 @@ class Autosuggest extends Component {
   }
 
   componentDidMount() {
-    global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
-    global.window.addEventListener('touchend', this.onDocumentMouseUp, false);
+    global.document.addEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.document.addEventListener('touchend', this.onDocumentMouseUp, false);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -96,8 +96,8 @@ class Autosuggest extends Component {
   }
 
   componentWillUnmount() {
-    global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
-    global.window.removeEventListener('touchend', this.onDocumentMouseUp, false);
+    global.document.removeEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.document.removeEventListener('touchend', this.onDocumentMouseUp, false);
   }
 
   onDocumentMouseUp() {


### PR DESCRIPTION
### Current behaviour

Previously `justClickedOnSuggestion` is set on `touchstart` or `mousedown` on a suggestion, but only reset when `click` events are triggered from a suggestion. If a user mousedown's or touchstart's on a suggestion, then drags outside the component, a click event is never triggered from a suggestion, so the flag remains set. To replicate the issue:
- On the demo page, click or tap the input for the the 'basic' example
- type 'c'
- mousedown or touchstart over any of the suggestions
- drag outside the suggestion list and release the mouse or your finger
- click on the 'Multiple Suggestions' input
- the 'Multiple Suggestions' input gains focus, but the suggestion list for the 'basic' example remains displayed
### Changes
- add a `onDocumentMouseUp` method that resets `justClickedOnSuggestion` on `mouseup` and `touchend` on the document.

I tried to add unit tests for this, but wasn't able to trigger events from the document using the react test utils.
