### PR TITLE
Use custom host and port

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,13 +1,15 @@
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.dev.config');
+var host = process.env.NODE_HOST || 'localhost';
+var port = process.env.NODE_PORT || 3000;
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath
-}).listen(3000, 'localhost', function(error) {
+}).listen(port, host, function(error) {
   if (error) {
     console.error(error); // eslint-disable-line no-console
   } else {
-    console.log('Demo is ready at http://localhost:3000/demo/dist/index.html'); // eslint-disable-line no-console
+    console.log(`Demo is ready at http://${host}:${port}/demo/dist/index.html`); // eslint-disable-line no-console
   }
 });

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -3,12 +3,15 @@ var webpack = require('webpack');
 var autoprefixer = require('autoprefixer');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HappyPack = require('happypack');
+var host = process.env.NODE_HOST || 'localhost';
+var port = process.env.NODE_PORT || 3000;
 
 module.exports = {
   entry: [
-    'webpack-dev-server/client?http://localhost:3000',
+    `webpack-dev-server/client?http://${host}:${port}`,
     './demo/src/index'
   ],
+
 
   output: {
     path: path.join(__dirname, 'dist'), // Must be an absolute path


### PR DESCRIPTION
In order to test on other devices on my LAN I needed to be able to set the host to my ip. eg if my ip was `10.4.1.19`, then run:

```NODE_HOST=10.4.1.19 npm start```

Then navigate to http://10.4.1.19:3000/demo/dist on another device (eg ipad or smart phone) on your LAN

`npm start` continues to work on http://localhost:3000