### PR TITLE
Update code to use bindActionCreators provided by redux

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { inputFocused, inputBlurred, inputChanged, updateFocusedSuggestion,
-         revealSuggestions, closeSuggestions } from './reducerAndActions';
+import { actionCreators } from './reducerAndActions';
 import Autowhatever from 'react-autowhatever';
 
 function mapStateToProps(state) {
@@ -16,26 +16,7 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return {
-    inputFocused: shouldRenderSuggestions => {
-      dispatch(inputFocused(shouldRenderSuggestions));
-    },
-    inputBlurred: () => {
-      dispatch(inputBlurred());
-    },
-    inputChanged: (shouldRenderSuggestions, lastAction) => {
-      dispatch(inputChanged(shouldRenderSuggestions, lastAction));
-    },
-    updateFocusedSuggestion: (sectionIndex, suggestionIndex, value) => {
-      dispatch(updateFocusedSuggestion(sectionIndex, suggestionIndex, value));
-    },
-    revealSuggestions: () => {
-      dispatch(revealSuggestions());
-    },
-    closeSuggestions: lastAction => {
-      dispatch(closeSuggestions(lastAction));
-    }
-  };
+  return bindActionCreators(actionCreators, dispatch);
 }
 
 class Autosuggest extends Component {

--- a/src/reducerAndActions.js
+++ b/src/reducerAndActions.js
@@ -5,20 +5,20 @@ const UPDATE_FOCUSED_SUGGESTION = 'UPDATE_FOCUSED_SUGGESTION';
 const REVEAL_SUGGESTIONS = 'REVEAL_SUGGESTIONS';
 const CLOSE_SUGGESTIONS = 'CLOSE_SUGGESTIONS';
 
-export function inputFocused(shouldRenderSuggestions) {
+function inputFocused(shouldRenderSuggestions) {
   return {
     type: INPUT_FOCUSED,
     shouldRenderSuggestions
   };
 }
 
-export function inputBlurred() {
+function inputBlurred() {
   return {
     type: INPUT_BLURRED
   };
 }
 
-export function inputChanged(shouldRenderSuggestions, lastAction) {
+function inputChanged(shouldRenderSuggestions, lastAction) {
   return {
     type: INPUT_CHANGED,
     shouldRenderSuggestions,
@@ -26,7 +26,7 @@ export function inputChanged(shouldRenderSuggestions, lastAction) {
   };
 }
 
-export function updateFocusedSuggestion(sectionIndex, suggestionIndex, value) {
+function updateFocusedSuggestion(sectionIndex, suggestionIndex, value) {
   return {
     type: UPDATE_FOCUSED_SUGGESTION,
     sectionIndex,
@@ -35,18 +35,27 @@ export function updateFocusedSuggestion(sectionIndex, suggestionIndex, value) {
   };
 }
 
-export function revealSuggestions() {
+function revealSuggestions() {
   return {
     type: REVEAL_SUGGESTIONS
   };
 }
 
-export function closeSuggestions(lastAction) {
+function closeSuggestions(lastAction) {
   return {
     type: CLOSE_SUGGESTIONS,
     lastAction
   };
 }
+
+export const actionCreators = {
+  inputFocused,
+  inputBlurred,
+  inputChanged,
+  updateFocusedSuggestion,
+  revealSuggestions,
+  closeSuggestions
+};
 
 export default function reducer(state, action) {
   switch (action.type) {


### PR DESCRIPTION
Hey there,

In this PR i simply refactor the `mapDispatchToProps` method to use `bindActionCreators` provided by the version of redux you're already using. It cleans up the code a little bit.