### PR TITLE
switch onChange to onInput because of IE11 react bug

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -158,10 +158,10 @@ class Autosuggest extends Component {
   }
 
   maybeCallOnChange(event, newValue, method) {
-    const { value, onChange } = this.props.inputProps;
+    const { value, onInput } = this.props.inputProps;
 
     if (newValue !== value) {
-      onChange && onChange(event, { newValue, method });
+      onInput && onInput(event, { newValue, method });
     }
   }
 
@@ -308,7 +308,7 @@ class Autosuggest extends Component {
           this.onSuggestionsClearRequested();
         }
       },
-      onChange: event => {
+      onInput: event => {
         const { value } = event.target;
         const shouldRender = shouldRenderSuggestions(value);
 

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -74,8 +74,8 @@ export default class AutosuggestContainer extends Component {
         throw new Error('\'inputProps\' must have \'value\'.');
       }
 
-      if (!inputProps.hasOwnProperty('onChange')) {
-        throw new Error('\'inputProps\' must have \'onChange\'.');
+      if (!inputProps.hasOwnProperty('onInput')) {
+        throw new Error('\'inputProps\' must have \'onInput\'.');
       }
     },
     shouldRenderSuggestions: PropTypes.func,


### PR DESCRIPTION
The reason for this PR is because of this React Bug: https://github.com/facebook/react/issues/7027

Instead of waiting for React v16, we are editing this component to use onInput instead of onChange to see if that helps IE11.

This breaks all the tests and just replacing "onChange" with "onInput" didn't fix the tests.