### PR TITLE
Fix Uncaught TypeError: Cannot read property 'trim' of undefined

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -427,7 +427,7 @@ class Autosuggest extends Component {
       }
     };
     const renderSuggestionData = {
-      query: (valueBeforeUpDown || value).trim()
+      query: (valueBeforeUpDown || value || "").trim()
     };
 
     return (


### PR DESCRIPTION
In one input I use react-autosuggest to display suggestions BEFORE the user start typing.
If this case if the user press `down`, I get:
```
Uncaught TypeError: Cannot read property 'trim' of undefined
```

This small change  the problem.