### PR TITLE
Feature textarea

### DIFF
--- a/demo/src/components/App/components/Examples/Examples.js
+++ b/demo/src/components/App/components/Examples/Examples.js
@@ -5,6 +5,7 @@ import Basic from 'Basic/Basic';
 import MultipleSections from 'MultipleSections/MultipleSections';
 import CustomRender from 'CustomRender/CustomRender';
 import ScrollableContainer from 'ScrollableContainer/ScrollableContainer';
+import TextareaRender from 'TextareaRender/TextareaRender';
 
 const Examples = () => (
   <div className={styles.container}>
@@ -15,6 +16,7 @@ const Examples = () => (
     <MultipleSections />
     <CustomRender />
     <ScrollableContainer />
+    <TextareaRender />
   </div>
 );
 

--- a/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.js
+++ b/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.js
@@ -1,0 +1,127 @@
+import styles from './TextareaRender.less';
+
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import Autosuggest from 'AutosuggestContainer';
+
+const data = [
+  { label: 'Alice' },
+  { label: 'Bob' }
+];
+
+const getTokenForSuggestions = (str, caretPosition) => {
+  let word;
+
+  let left  = str.slice(0, caretPosition).search(/\S+$/);
+  let right = str.slice(caretPosition).search(/\s/);
+
+  if (right < 0) {
+    word = str.slice(left);
+  } else {
+    word = str.slice(left, right + caretPosition);
+  }
+
+  if (!word || word.trim().length < 2 || word[0] !== '@') {
+    return null;
+  }
+
+  word = word.trim().toLowerCase().slice(1);
+
+  if (word.length > 0) {
+    return word;
+  } else {
+    return null;
+  }
+};
+
+const fetchSuggestions = (token) => {
+  return data.filter(item => item.label.toLowerCase().slice(0, token.length) === token).map(item => ({ ...item, completion: item.label.slice(token.length) }));
+};
+
+const getSuggestionValue = suggestion => suggestion.completion;
+
+const renderSuggestion = suggestion => (
+  <span>{suggestion.label}</span>
+);
+
+const renderInputComponent = inputProps => (
+  <textarea {...inputProps} />
+);
+
+export default class TextareaRender extends Component {
+
+  constructor() {
+    super();
+
+    this.state = {
+      text: '',
+      suggestions: []
+    };
+  }
+
+  onSuggestionsClearRequested = () => {
+    this.setState({ suggestions: [] });
+  };
+
+  onSuggestionsFetchRequested = ({ value }) => {
+    const node     = ReactDOM.findDOMNode(this.refs.autosuggest);
+    const textarea = node.querySelector('textarea');
+
+    if (textarea) {
+      const token = getTokenForSuggestions(value, textarea.selectionStart);
+
+      if (token !== null) {
+        this.setState({ suggestions: fetchSuggestions(token) });
+      } else {
+        this.setState({ suggestions: [] });
+      }
+    }
+  };
+
+  onSuggestionSelected = (e, { suggestionValue, method }) => {
+    const node     = ReactDOM.findDOMNode(this.refs.autosuggest);
+    const textarea = node.querySelector('textarea');
+
+    if (textarea) {
+      const str = this.state.text;
+      this.setState({ text: [str.slice(0, textarea.selectionStart), suggestionValue, str.slice(textarea.selectionStart)].join('') });
+    }
+  };
+
+  handleChange = e => {
+    this.setState({ text: e.target.value });
+  };
+
+  render () {
+    const inputProps = {
+      value: this.state.text,
+      onChange: this.handleChange
+    };
+
+    return (
+      <div id="textarea-render-example" className={styles.container}>
+        <div className={styles.textContainer}>
+          <div className={styles.title}>
+            Textarea
+          </div>
+          <div className={styles.description}>
+            Try typing a text with @alice or @bob
+          </div>
+        </div>
+        <div className={styles.autosuggest}>
+          <Autosuggest
+            ref='autosuggest'
+            suggestions={this.state.suggestions}
+            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+            onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+            onSuggestionSelected={this.onSuggestionSelected}
+            getSuggestionValue={getSuggestionValue}
+            renderSuggestion={renderSuggestion}
+            renderInputComponent={renderInputComponent}
+            inputProps={inputProps}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.js
+++ b/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.js
@@ -1,7 +1,6 @@
 import styles from './TextareaRender.less';
 
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import Autosuggest from 'AutosuggestContainer';
 
 const data = [
@@ -64,8 +63,7 @@ export default class TextareaRender extends Component {
   };
 
   onSuggestionsFetchRequested = ({ value }) => {
-    const node     = ReactDOM.findDOMNode(this.refs.autosuggest);
-    const textarea = node.querySelector('textarea');
+    const textarea = this.autosuggest.input;
 
     if (textarea) {
       const token = getTokenForSuggestions(value, textarea.selectionStart);
@@ -78,12 +76,12 @@ export default class TextareaRender extends Component {
     }
   };
 
-  onSuggestionSelected = (e, { suggestionValue, method }) => {
-    const node     = ReactDOM.findDOMNode(this.refs.autosuggest);
-    const textarea = node.querySelector('textarea');
+  onSuggestionSelected = (e, { suggestionValue }) => {
+    const textarea = this.autosuggest.input;
 
     if (textarea) {
       const str = this.state.text;
+
       this.setState({ text: [str.slice(0, textarea.selectionStart), suggestionValue, str.slice(textarea.selectionStart)].join('') });
     }
   };
@@ -92,7 +90,11 @@ export default class TextareaRender extends Component {
     this.setState({ text: e.target.value });
   };
 
-  render () {
+  setRef = c => {
+    this.autosuggest = c;
+  };
+
+  render() {
     const inputProps = {
       value: this.state.text,
       onChange: this.handleChange
@@ -110,8 +112,9 @@ export default class TextareaRender extends Component {
         </div>
         <div className={styles.autosuggest}>
           <Autosuggest
-            ref='autosuggest'
+            ref={this.setRef}
             suggestions={this.state.suggestions}
+            focusFirstSuggestion={true}
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
             onSuggestionsClearRequested={this.onSuggestionsClearRequested}
             onSuggestionSelected={this.onSuggestionSelected}

--- a/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.less
+++ b/demo/src/components/App/components/Examples/components/TextareaRender/TextareaRender.less
@@ -1,0 +1,55 @@
+@import '~variables';
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  width: 34 * @columns;
+  margin: (11 * @rows) (0.5 * @column) 0;
+
+  @media @examples-vertical {
+    flex-direction: column;
+    width: 14 * @columns;
+    margin-top: 9 * @rows;
+  }
+
+  @media @small {
+    margin-top: 7 * @rows;
+  }
+}
+
+.textContainer {
+  display: flex;
+  flex-direction: column;
+  width: 15 * @columns;
+}
+
+.title {
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 5 * @rows;
+
+  @media @small {
+    font-size: 25px;
+  }
+}
+
+.description {
+  margin-top: @row;
+  font-size: 20px;
+}
+
+.codepenLink {
+  margin-top: @row;
+  font-size: 20px;
+  color: #209FD3;
+  align-self: flex-start;
+}
+
+.autosuggest {
+  margin-top: 6 * @rows;
+
+  @media @examples-vertical {
+    margin-top: 3 * @rows;
+    margin-left: 0;
+  }
+}

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -333,6 +333,8 @@ class Autosuggest extends Component {
               if (shouldRenderSuggestions(value)) {
                 onSuggestionsFetchRequested({ value });
                 revealSuggestions();
+
+                event.preventDefault(); // Prevents the cursor from moving
               }
             } else if (suggestions.length > 0) {
               const { newFocusedSectionIndex, newFocusedItemIndex } = data;
@@ -350,12 +352,13 @@ class Autosuggest extends Component {
 
               updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value);
               this.maybeCallOnChange(event, newValue, event.key === 'ArrowDown' ? 'down' : 'up');
-            }
 
-            event.preventDefault(); // Prevents the cursor from moving
+              event.preventDefault(); // Prevents the cursor from moving
+            }
 
             break;
 
+          case 'Tab':
           case 'Enter': {
             const focusedSuggestion = this.getFocusedSuggestion();
 
@@ -373,13 +376,16 @@ class Autosuggest extends Component {
                 method: 'enter'
               });
 
-              this.maybeCallOnChange(event, newValue, 'enter');
+              //this.maybeCallOnChange(event, newValue, 'enter');
 
               this.justSelectedSuggestion = true;
 
               setTimeout(() => {
                 this.justSelectedSuggestion = false;
               });
+
+              event.preventDefault();
+              event.stopPropagation();
             }
 
             break;

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -114,7 +114,7 @@ describe('Autosuggest with focusFirstSuggestion={true}', () => {
       onChange.reset();
     });
 
-    it('should be called once with the right parameters when Enter is pressed after autofocus', () => {
+    xit('should be called once with the right parameters when Enter is pressed after autofocus', () => {
       clickEnter();
       expect(onChange).to.have.been.calledOnce;
       expect(onChange).to.be.calledWith(syntheticEventMatcher, {


### PR DESCRIPTION
See #281. This PR changes the behaviour slightly, which is why I had to disable one test case for old behaviour, hopefully you can figure out if it's something you'd want to adjust or remove.

Changes:

- Do not suppress up/down arrow key presses when no suggestions are loaded (in-textarea navigation).
- Add the same behaviour to <kbd>Tab</kbd> key as <kbd>Enter</kbd> key.
- Suppress <kbd>Tab</kbd>/<kbd>Enter</kbd> key presses when a suggestion is being selected (aka prevent line break/focus switch when you're selecting a suggestion).
- Remove call to `maybeCallOnChange` from <kbd>Tab</kbd>/<kbd>Enter</kbd> key press, because otherwise whatever the `onSuggestionSelected` handler does will be overwritten by the value passed to `maybeCallOnChange` immediately.

Furthermore, a textarea example is added to the demo.