### PR TITLE
Call onSuggestionSelected after onChange

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -366,14 +366,13 @@ class Autosuggest extends Component {
             if (focusedSuggestion !== null) {
               const newValue = getSuggestionValue(focusedSuggestion);
 
+              this.maybeCallOnChange(event, newValue, 'enter');
               this.onSuggestionSelected(event, {
                 suggestion: focusedSuggestion,
                 suggestionValue: newValue,
                 sectionIndex: focusedSectionIndex,
                 method: 'enter'
               });
-
-              this.maybeCallOnChange(event, newValue, 'enter');
 
               this.justSelectedSuggestion = true;
 

--- a/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.js
+++ b/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autosuggest from '../../src/AutosuggestContainer';
+import languages from '../plain-list/languages';
+import { escapeRegexCharacters } from '../../demo/src/components/utils/utils.js';
+
+const getMatchingLanguages = value => {
+  const escapedValue = escapeRegexCharacters(value.trim());
+  const regex = new RegExp('^' + escapedValue, 'i');
+
+  return languages.filter(language => regex.test(language.name));
+};
+
+let app = null;
+
+export const getSuggestionValue = sinon.spy(suggestion => {
+  return suggestion.name;
+});
+
+export const renderSuggestion = sinon.spy(suggestion => {
+  return (
+    <span>{suggestion.name}</span>
+  );
+});
+
+export const onChange = sinon.spy((event, { newValue }) => {
+  app.setState({
+    value: newValue
+  });
+});
+
+export const onSuggestionsFetchRequested = sinon.spy(({ value }) => {
+  app.setState({
+    suggestions: getMatchingLanguages(value)
+  });
+});
+
+export const onSuggestionsClearRequested = sinon.spy(() => {
+  app.setState({
+    suggestions: []
+  });
+});
+
+export const onSuggestionSelected = sinon.spy(() => {
+  app.setState({ value: '' });
+});
+
+export default class AutosuggestApp extends Component {
+  constructor() {
+    super();
+
+    app = this;
+
+    this.state = {
+      value: '',
+      suggestions: []
+    };
+  }
+
+  render() {
+    const { value, suggestions } = this.state;
+    const inputProps = {
+      value,
+      onChange
+    };
+
+    return (
+      <Autosuggest
+        suggestions={suggestions.slice()}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        onSuggestionSelected={onSuggestionSelected}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        inputProps={inputProps}
+        focusFirstSuggestion={true}
+      />
+    );
+  }
+}

--- a/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  syntheticEventMatcher,
+  expectInputValue,
+  expectSuggestions,
+  expectFocusedSuggestion,
+  mouseEnterSuggestion,
+  mouseLeaveSuggestion,
+  focusInput,
+  blurInput,
+  clickEscape,
+  clickEnter,
+  clickDown,
+  setInputValue,
+  focusAndSetInputValue
+} from '../helpers';
+import AutosuggestApp, {
+  onChange,
+  onSuggestionSelected
+} from './AutosuggestApp';
+
+describe('Autosuggest with focusFirstSuggestion={true}', () => {
+  beforeEach(() => {
+    init(TestUtils.renderIntoDocument(<AutosuggestApp />));
+  });
+
+  describe('when typing and matches exist', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('j');
+    });
+
+    it('should focus on the first suggestion', () => {
+      expectFocusedSuggestion('Java');
+    });
+
+    it('should focus on the first suggestion when typing a character does not change the suggestions', () => {
+      focusAndSetInputValue('ja');
+      expectFocusedSuggestion('Java');
+    });
+
+    it('should focus on the first suggestion when input is focused after it has been blurred', () => {
+      blurInput();
+      focusInput();
+      expectFocusedSuggestion('Java');
+    });
+
+    it('should focus on the first suggestion when same suggestions are shown again', () => {
+      setInputValue('');
+      setInputValue('j');
+      expectFocusedSuggestion('Java');
+    });
+
+    it('should focus on suggestion when mouse enters it', () => {
+      mouseEnterSuggestion(1);
+      expectFocusedSuggestion('Javascript');
+    });
+
+    it('should not have focused suggestions when mouse leaves a suggestion', () => {
+      mouseEnterSuggestion(1);
+      mouseLeaveSuggestion(1);
+      expectFocusedSuggestion(null);
+    });
+  });
+
+  describe('when pressing Down', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('j');
+    });
+
+    it('should focus on the second suggestion', () => {
+      clickDown();
+      expectFocusedSuggestion('Javascript');
+    });
+
+    it('should not focus on any suggestion after reaching the last suggestion', () => {
+      clickDown(2);
+      expectFocusedSuggestion(null);
+    });
+
+    it('should focus on the first suggestion when suggestions are revealed', () => {
+      clickEscape();
+      clickDown();
+      expectFocusedSuggestion('Java');
+    });
+  });
+
+  describe('when pressing Enter', () => {
+    it('should hide suggestions if the first suggestion was autofocused', () => {
+      focusAndSetInputValue('p');
+      clickEnter();
+      expectSuggestions([]);
+    });
+
+    it('should hide suggestions if mouse entered another suggestion after autofocus', () => {
+      focusAndSetInputValue('p');
+      mouseEnterSuggestion(2);
+      clickEnter();
+      expectSuggestions([]);
+    });
+
+    it('should not error if there are no suggestions', () => {
+      focusAndSetInputValue('z');
+      clickEnter();
+      expectInputValue('z');
+    });
+  });
+
+  describe('inputProps.onChange', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      onChange.reset();
+    });
+
+    it('should be called once with the right parameters when Enter is pressed after autofocus', () => {
+      clickEnter();
+      expect(onChange).to.have.been.calledOnce;
+      expect(onChange).to.be.calledWith(syntheticEventMatcher, {
+        newValue: 'Perl',
+        method: 'enter'
+      });
+    });
+  });
+
+  describe('onSuggestionSelected', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      onSuggestionSelected.reset();
+    });
+
+    it('should be called once with the right parameters when Enter is pressed after autofocus', () => {
+      clickEnter();
+      expect(onSuggestionSelected).to.have.been.calledOnce;
+      expect(onSuggestionSelected).to.have.been.calledWithExactly(syntheticEventMatcher, {
+        suggestion: { name: 'Perl', year: 1987 },
+        suggestionValue: 'Perl',
+        sectionIndex: null,
+        method: 'enter'
+      });
+    });
+  });
+});

--- a/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
@@ -1,144 +1,32 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-import { expect } from 'chai';
 import {
   init,
-  syntheticEventMatcher,
   expectInputValue,
-  expectSuggestions,
-  expectFocusedSuggestion,
-  mouseEnterSuggestion,
-  mouseLeaveSuggestion,
-  focusInput,
-  blurInput,
-  clickEscape,
-  clickEnter,
   clickDown,
-  setInputValue,
+  clickEnter,
   focusAndSetInputValue
 } from '../helpers';
-import AutosuggestApp, {
-  onChange,
-  onSuggestionSelected
-} from './AutosuggestApp';
+import AutosuggestApp from './AutosuggestApp';
 
-describe('Autosuggest with focusFirstSuggestion={true}', () => {
+describe('Autosuggest with focusFirstSuggestion={true} and clear on Enter', () => {
   beforeEach(() => {
     init(TestUtils.renderIntoDocument(<AutosuggestApp />));
   });
 
-  describe('when typing and matches exist', () => {
-    beforeEach(() => {
-      focusAndSetInputValue('j');
+  describe('when pressing Enter to select a suggestion', () => {
+    it('should clear input after selecting first suggestion', () => {
+      focusAndSetInputValue('c');
+      clickEnter();
+      expectInputValue('');
     });
 
-    it('should focus on the first suggestion', () => {
-      expectFocusedSuggestion('Java');
-    });
-
-    it('should focus on the first suggestion when typing a character does not change the suggestions', () => {
-      focusAndSetInputValue('ja');
-      expectFocusedSuggestion('Java');
-    });
-
-    it('should focus on the first suggestion when input is focused after it has been blurred', () => {
-      blurInput();
-      focusInput();
-      expectFocusedSuggestion('Java');
-    });
-
-    it('should focus on the first suggestion when same suggestions are shown again', () => {
-      setInputValue('');
-      setInputValue('j');
-      expectFocusedSuggestion('Java');
-    });
-
-    it('should focus on suggestion when mouse enters it', () => {
-      mouseEnterSuggestion(1);
-      expectFocusedSuggestion('Javascript');
-    });
-
-    it('should not have focused suggestions when mouse leaves a suggestion', () => {
-      mouseEnterSuggestion(1);
-      mouseLeaveSuggestion(1);
-      expectFocusedSuggestion(null);
-    });
-  });
-
-  describe('when pressing Down', () => {
-    beforeEach(() => {
-      focusAndSetInputValue('j');
-    });
-
-    it('should focus on the second suggestion', () => {
+    it('should clear input after selecting second suggestion', () => {
+      focusAndSetInputValue('c');
       clickDown();
-      expectFocusedSuggestion('Javascript');
-    });
-
-    it('should not focus on any suggestion after reaching the last suggestion', () => {
-      clickDown(2);
-      expectFocusedSuggestion(null);
-    });
-
-    it('should focus on the first suggestion when suggestions are revealed', () => {
-      clickEscape();
-      clickDown();
-      expectFocusedSuggestion('Java');
+      clickEnter();
+      expectInputValue('');
     });
   });
 
-  describe('when pressing Enter', () => {
-    it('should hide suggestions if the first suggestion was autofocused', () => {
-      focusAndSetInputValue('p');
-      clickEnter();
-      expectSuggestions([]);
-    });
-
-    it('should hide suggestions if mouse entered another suggestion after autofocus', () => {
-      focusAndSetInputValue('p');
-      mouseEnterSuggestion(2);
-      clickEnter();
-      expectSuggestions([]);
-    });
-
-    it('should not error if there are no suggestions', () => {
-      focusAndSetInputValue('z');
-      clickEnter();
-      expectInputValue('z');
-    });
-  });
-
-  describe('inputProps.onChange', () => {
-    beforeEach(() => {
-      focusAndSetInputValue('p');
-      onChange.reset();
-    });
-
-    it('should be called once with the right parameters when Enter is pressed after autofocus', () => {
-      clickEnter();
-      expect(onChange).to.have.been.calledOnce;
-      expect(onChange).to.be.calledWith(syntheticEventMatcher, {
-        newValue: 'Perl',
-        method: 'enter'
-      });
-    });
-  });
-
-  describe('onSuggestionSelected', () => {
-    beforeEach(() => {
-      focusAndSetInputValue('p');
-      onSuggestionSelected.reset();
-    });
-
-    it('should be called once with the right parameters when Enter is pressed after autofocus', () => {
-      clickEnter();
-      expect(onSuggestionSelected).to.have.been.calledOnce;
-      expect(onSuggestionSelected).to.have.been.calledWithExactly(syntheticEventMatcher, {
-        suggestion: { name: 'Perl', year: 1987 },
-        suggestionValue: 'Perl',
-        sectionIndex: null,
-        method: 'enter'
-      });
-    });
-  });
 });

--- a/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
@@ -15,13 +15,13 @@ describe('Autosuggest with focusFirstSuggestion={true} and clear on Enter', () =
   });
 
   describe('when pressing Enter to select a suggestion', () => {
-    it('should clear input after selecting first suggestion', () => {
+    it('should clear the input after selecting first suggestion', () => {
       focusAndSetInputValue('c');
       clickEnter();
       expectInputValue('');
     });
 
-    it('should clear input after selecting second suggestion', () => {
+    it('should clear the input after selecting second suggestion', () => {
       focusAndSetInputValue('c');
       clickDown();
       clickEnter();


### PR DESCRIPTION
This PR fixes #305, please read the issue for a more in-depth look at the problem.

In that issue, I suggested that we should prevent the call to `onChange` if the submission method was `Enter` KeyDown. After some thinking and reading of the code, it makes a lot more sense to simply move the `maybeCallOnChange` call above the `onSuggestionSelected` call instead.

The idea is that we want `onSuggestionSelected` to take precedence over `onChange`, since the user's ultimate intention is to select the suggestion.

This is exactly what is done for the `click` action already. So it makes sense that the `enter` action should behave similarly. This PR simply brings it in line with that behaviour.

Note: [Lines 228 to 234](https://github.com/moroshko/react-autosuggest/blob/master/src/Autosuggest.js#L228-L234) is where this happens for the click event.

```js
this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
this.onSuggestionSelected(event, {
  suggestion: clickedSuggestion,
  suggestionValue: clickedSuggestionValue,
  sectionIndex,
  method: 'click'
});
```

I've made two tests for the feature. Note that I had to create a new folder for the test because I needed a `onSuggestionSelected` function that clears the input value with `this.setState({ value: '' })`.

This PR passes all tests, linting, and the build process.