### PR TITLE
Pass suggestionIndex to onSuggestionSelected

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ where:
 This function is called when suggestion is selected. It has the following signature:
 
 ```js
-function onSuggestionSelected(event, { suggestion, suggestionValue, suggestionIndex,sectionIndex, method })
+function onSuggestionSelected(event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method })
 ```
 
 where:

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ where:
 
 * `suggestion` - the selected suggestion
 * `suggestionValue` - the value of the selected suggestion (equivalent to `getSuggestionValue(suggestion)`)
+* `suggestionIndex` - the index of the selected suggestion in the `suggestions` array )
 * `sectionIndex` - when rendering [multiple sections](#multiSectionProp), this will be the section index (in [`suggestions`](#suggestionsProp)) of the selected suggestion. Otherwise, it will be `null`.
 * `method` - string describing how user selected the suggestion. The possible values are:
   * `'click'` - user clicked (or tapped) on the suggestion

--- a/README.md
+++ b/README.md
@@ -344,14 +344,14 @@ where:
 This function is called when suggestion is selected. It has the following signature:
 
 ```js
-function onSuggestionSelected(event, { suggestion, suggestionValue, sectionIndex, method })
+function onSuggestionSelected(event, { suggestion, suggestionValue, suggestionIndex,sectionIndex, method })
 ```
 
 where:
 
 * `suggestion` - the selected suggestion
 * `suggestionValue` - the value of the selected suggestion (equivalent to `getSuggestionValue(suggestion)`)
-* `suggestionIndex` - the index of the selected suggestion in the `suggestions` array )
+* `suggestionIndex` - the index of the selected suggestion in the `suggestions` array
 * `sectionIndex` - when rendering [multiple sections](#multiSectionProp), this will be the section index (in [`suggestions`](#suggestionsProp)) of the selected suggestion. Otherwise, it will be `null`.
 * `method` - string describing how user selected the suggestion. The possible values are:
   * `'click'` - user clicked (or tapped) on the suggestion

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -229,6 +229,7 @@ class Autosuggest extends Component {
     this.onSuggestionSelected(event, {
       suggestion: clickedSuggestion,
       suggestionValue: clickedSuggestionValue,
+      suggestionIndex: suggestionIndex,
       sectionIndex,
       method: 'click'
     });
@@ -371,6 +372,7 @@ class Autosuggest extends Component {
               this.onSuggestionSelected(event, {
                 suggestion: focusedSuggestion,
                 suggestionValue: newValue,
+                suggestionIndex: focusedSuggestionIndex,
                 sectionIndex: focusedSectionIndex,
                 method: 'enter'
               });

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -136,6 +136,7 @@ describe('Autosuggest with focusFirstSuggestion={true}', () => {
       expect(onSuggestionSelected).to.have.been.calledWithExactly(syntheticEventMatcher, {
         suggestion: { name: 'Perl', year: 1987 },
         suggestionValue: 'Perl',
+        suggestionIndex: 0,
         sectionIndex: null,
         method: 'enter'
       });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -545,6 +545,7 @@ describe('Default Autosuggest', () => {
       expect(onSuggestionSelected).to.have.been.calledWithExactly(syntheticEventMatcher, {
         suggestion: { name: 'Javascript', year: 1995 },
         suggestionValue: 'Javascript',
+        suggestionIndex: 1,
         sectionIndex: null,
         method: 'click'
       });
@@ -557,6 +558,7 @@ describe('Default Autosuggest', () => {
       expect(onSuggestionSelected).to.have.been.calledWithExactly(syntheticEventMatcher, {
         suggestion: { name: 'Java', year: 1995 },
         suggestionValue: 'Java',
+        suggestionIndex: 0,
         sectionIndex: null,
         method: 'enter'
       });


### PR DESCRIPTION
Hi @moroshko! 

I’ve needed the `suggestionIndex` of the selected suggestion a couple of times in my application. 

So, I figured I would make a quick PR to see if this is something you’d like to add to the library.

Thank you for providing this library!