### PR TITLE
Fix error when setting focusInputOnSuggestionClick to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autosuggest",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -422,6 +422,7 @@ export default class Autosuggest extends Component {
           return;
         }
 
+        event.persist();
         this.blurEvent = event;
 
         if (!this.justSelectedSuggestion) {


### PR DESCRIPTION
Fix error when setting focusInputOnSuggestionClick to false and using component 
with HOC (like Redux Form) listening for onBlur callback.

Fixes #275.
