### PR TITLE
Add optional onSuggestionFocused prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ class Example extends React.Component {
 | [`renderSuggestion`](#renderSuggestionProp) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#inputPropsProp) | Object | ✓ | Pass through arbitrary props to the input. It must contain at least `value` and `onChange`. |
 | [`onSuggestionSelected`](#onSuggestionSelectedProp) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
-| [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | Will be called every time suggestion is highlighted via mouse or keyboard. |
+| [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | | Will be called every time suggestion is highlighted via mouse or keyboard. |
 | [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp) | Function | | When the input is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
 | [`alwaysRenderSuggestions`](#alwaysRenderSuggestionsProp) | Boolean | | Set it to `true` if you'd like to render suggestions even when the input is not focused. |
 | [`highlightFirstSuggestion`](#highlightFirstSuggestionProp) | Boolean | | Set it to `true` if you'd like Autosuggest to automatically highlight the first suggestion. |

--- a/README.md
+++ b/README.md
@@ -376,14 +376,14 @@ where:
 <a name="onSuggestionHighlightedProp"></a>
 #### onSuggestionHighlighted (optional)
 
-This function is called when suggestion is focused. It has the following signature:
+This function is called when the highlighted suggestion changes. It has the following signature:
 
 ```js
 function onSuggestionHighlighted({ suggestion })
 ```
 
 where:
-* `suggestion` - the focused suggestion(set to `null` when unfocused)
+* `suggestion` - the highlighted suggestion, or `null` if there is no highlighted suggestion.
 
 <a name="shouldRenderSuggestionsProp"></a>
 #### shouldRenderSuggestions (optional)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ class Example extends React.Component {
 | [`renderSuggestion`](#renderSuggestionProp) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#inputPropsProp) | Object | ✓ | Pass through arbitrary props to the input element. It must contain at least `value` and `onChange`. |
 | [`onSuggestionSelected`](#onSuggestionSelectedProp) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
-| [`onSuggestionFocused`](#onSuggestionFocusedProp) | Function | Will be called every time suggestion is focused via mouse or keyboard. |
+| [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | Will be called every time suggestion is focused via mouse or keyboard. |
 | [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp) | Function | | When the input element is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
 | [`alwaysRenderSuggestions`](#alwaysRenderSuggestionsProp) | Boolean | | Set it to `true` if you'd like to render suggestions even when the input element is not focused. |
 | [`highlightFirstSuggestion`](#highlightFirstSuggestionProp) | Boolean | | Set it to `true` if you'd like Autosuggest to automatically highlight the first suggestion. |
@@ -365,13 +365,13 @@ where:
   * `'click'` - user clicked (or tapped) on the suggestion
   * `'enter'` - user selected the suggestion using <kbd>Enter</kbd>
 
-<a name="onSuggestionFocusedProp"></a>
-#### onSuggestionFocused (optional)
+<a name="onSuggestionHighlightedProp"></a>
+#### onSuggestionHighlighted (optional)
 
 This function is called when suggestion is focused. It has the following signature:
 
 ```js
-function onSuggestionFocused({ suggestion })
+function onSuggestionHighlighted({ suggestion })
 ```
 
 where:

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ class Example extends React.Component {
 | [`renderSuggestion`](#renderSuggestionProp) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#inputPropsProp) | Object | ✓ | Pass through arbitrary props to the input. It must contain at least `value` and `onChange`. |
 | [`onSuggestionSelected`](#onSuggestionSelectedProp) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
-| [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | | Will be called every time suggestion is highlighted via mouse or keyboard. |
+| [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | | Will be called every time the highlighted suggestion changes. |
 | [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp) | Function | | When the input is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
 | [`alwaysRenderSuggestions`](#alwaysRenderSuggestionsProp) | Boolean | | Set it to `true` if you'd like to render suggestions even when the input is not focused. |
 | [`highlightFirstSuggestion`](#highlightFirstSuggestionProp) | Boolean | | Set it to `true` if you'd like Autosuggest to automatically highlight the first suggestion. |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ class Example extends React.Component {
 | [`renderSuggestion`](#renderSuggestionProp) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#inputPropsProp) | Object | ✓ | Pass through arbitrary props to the input element. It must contain at least `value` and `onChange`. |
 | [`onSuggestionSelected`](#onSuggestionSelectedProp) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
+| [`onSuggestionFocused`](#onSuggestionFocusedProp) | Function | Will be called every time suggestion is focused via mouse or keyboard. |
 | [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp) | Function | | When the input element is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
 | [`alwaysRenderSuggestions`](#alwaysRenderSuggestionsProp) | Boolean | | Set it to `true` if you'd like to render suggestions even when the input element is not focused. |
 | [`highlightFirstSuggestion`](#highlightFirstSuggestionProp) | Boolean | | Set it to `true` if you'd like Autosuggest to automatically highlight the first suggestion. |
@@ -363,6 +364,18 @@ where:
 * `method` - string describing how user selected the suggestion. The possible values are:
   * `'click'` - user clicked (or tapped) on the suggestion
   * `'enter'` - user selected the suggestion using <kbd>Enter</kbd>
+
+<a name="onSuggestionFocusedProp"></a>
+#### onSuggestionFocused (optional)
+
+This function is called when suggestion is focused. It has the following signature:
+
+```js
+function onSuggestionFocused({ suggestion })
+```
+
+where:
+* `suggestion` - the focused suggestion(set to `null` when unfocused)
 
 <a name="shouldRenderSuggestionsProp"></a>
 #### shouldRenderSuggestions (optional)

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -140,15 +140,21 @@ export default class Autosuggest extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    const { onSuggestionHighlighted } = this.props;
+    
+    if (!onSuggestionHighlighted) {
+      return;
+    }
+    
     const { highlightedSectionIndex, highlightedSuggestionIndex } = this.state;
-    const hasFocusedSuggestionChanged =
-      highlightedSectionIndex !== prevState.highlightedSectionIndex ||
-      highlightedSuggestionIndex !== prevState.highlightedSuggestionIndex;
-
-    if (this.props.onSuggestionHighlighted && hasFocusedSuggestionChanged) {
+    
+    if (
+      highlightedSectionIndex !== prevState.highlightedSectionIndex || 
+      highlightedSuggestionIndex !== prevState.highlightedSuggestionIndex
+    ) {
       const suggestion = this.getHighlightedSuggestion();
 
-      this.props.onSuggestionHighlighted({ suggestion });
+      onSuggestionHighlighted({ suggestion });
     }
   }
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -34,6 +34,7 @@ export default class Autosuggest extends Component {
       }
     },
     onSuggestionSelected: PropTypes.func,
+    onSuggestionFocused: PropTypes.func,
     renderInputComponent: PropTypes.func,
     renderSuggestionsContainer: PropTypes.func,
     getSuggestionValue: PropTypes.func.isRequired,
@@ -135,6 +136,20 @@ export default class Autosuggest extends Component {
       } else {
         this.resetHighlightedSuggestion();
       }
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { highlightedSectionIndex, highlightedSuggestionIndex } = this.state;
+    const hasFocusedSuggestionChanged = (
+      highlightedSectionIndex !== prevState.highlightedSectionIndex ||
+      highlightedSuggestionIndex !== prevState.highlightedSuggestionIndex
+    );
+
+    if (this.props.onSuggestionFocused && hasFocusedSuggestionChanged) {
+      const suggestion = this.getHighlightedSuggestion();
+
+      this.props.onSuggestionFocused({ suggestion });
     }
   }
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -34,7 +34,7 @@ export default class Autosuggest extends Component {
       }
     },
     onSuggestionSelected: PropTypes.func,
-    onSuggestionFocused: PropTypes.func,
+    onSuggestionHighlighted: PropTypes.func,
     renderInputComponent: PropTypes.func,
     renderSuggestionsContainer: PropTypes.func,
     getSuggestionValue: PropTypes.func.isRequired,
@@ -141,15 +141,14 @@ export default class Autosuggest extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { highlightedSectionIndex, highlightedSuggestionIndex } = this.state;
-    const hasFocusedSuggestionChanged = (
+    const hasFocusedSuggestionChanged =
       highlightedSectionIndex !== prevState.highlightedSectionIndex ||
-      highlightedSuggestionIndex !== prevState.highlightedSuggestionIndex
-    );
+      highlightedSuggestionIndex !== prevState.highlightedSuggestionIndex;
 
-    if (this.props.onSuggestionFocused && hasFocusedSuggestionChanged) {
+    if (this.props.onSuggestionHighlighted && hasFocusedSuggestionChanged) {
       const suggestion = this.getHighlightedSuggestion();
 
-      this.props.onSuggestionFocused({ suggestion });
+      this.props.onSuggestionHighlighted({ suggestion });
     }
   }
 

--- a/test/focus-first-suggestion/AutosuggestApp.js
+++ b/test/focus-first-suggestion/AutosuggestApp.js
@@ -41,6 +41,8 @@ export const onSuggestionsClearRequested = sinon.spy(() => {
 
 export const onSuggestionSelected = sinon.spy();
 
+export const onSuggestionFocused = sinon.spy();
+
 export default class AutosuggestApp extends Component {
   constructor() {
     super();
@@ -66,6 +68,7 @@ export default class AutosuggestApp extends Component {
         onSuggestionsFetchRequested={onSuggestionsFetchRequested}
         onSuggestionsClearRequested={onSuggestionsClearRequested}
         onSuggestionSelected={onSuggestionSelected}
+        onSuggestionFocused={onSuggestionFocused}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}

--- a/test/focus-first-suggestion/AutosuggestApp.js
+++ b/test/focus-first-suggestion/AutosuggestApp.js
@@ -41,7 +41,7 @@ export const onSuggestionsClearRequested = sinon.spy(() => {
 
 export const onSuggestionSelected = sinon.spy();
 
-export const onSuggestionFocused = sinon.spy();
+export const onSuggestionHighlighted = sinon.spy();
 
 export default class AutosuggestApp extends Component {
   constructor() {
@@ -68,7 +68,7 @@ export default class AutosuggestApp extends Component {
         onSuggestionsFetchRequested={onSuggestionsFetchRequested}
         onSuggestionsClearRequested={onSuggestionsClearRequested}
         onSuggestionSelected={onSuggestionSelected}
-        onSuggestionFocused={onSuggestionFocused}
+        onSuggestionHighlighted={onSuggestionHighlighted}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -110,12 +110,9 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
   });
 
   describe('inputProps.onChange', () => {
-    beforeEach(() => {
+    it('should be called once with the right parameters when Enter is pressed after autohighlight', () => {
       focusAndSetInputValue('p');
       onChange.reset();
-    });
-
-    it('should be called once with the right parameters when Enter is pressed after autohighlight', () => {
       clickEnter();
       expect(onChange).to.have.been.calledOnce;
       expect(onChange).to.be.calledWith(syntheticEventMatcher, {
@@ -126,12 +123,9 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
   });
 
   describe('onSuggestionSelected', () => {
-    beforeEach(() => {
+    it('should be called once with the right parameters when Enter is pressed after autohighlight', () => {
       focusAndSetInputValue('p');
       onSuggestionSelected.reset();
-    });
-
-    it('should be called once with the right parameters when Enter is pressed after autohighlight', () => {
       clickEnter();
       expect(onSuggestionSelected).to.have.been.calledOnce;
       expect(
@@ -147,12 +141,9 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
   });
 
   describe('onSuggestionHighlighted', () => {
-    beforeEach(() => {
+    it('should be called once with the highlighed suggestion when the first suggestion is autohighlighted', () => {
       onSuggestionHighlighted.reset();
       focusAndSetInputValue('p');
-    });
-
-    it('should be called once with the right parameters when the first suggestion is autohighlighted', () => {
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
         suggestion: { name: 'Perl', year: 1987 }

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -152,7 +152,7 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
       focusAndSetInputValue('p');
     });
 
-    it('should be called once with the right paramter when the first suggestion is autohighlighted', () => {
+    it('should be called once with the right parameters when the first suggestion is autohighlighted', () => {
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
         suggestion: { name: 'Perl', year: 1987 }

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -19,7 +19,8 @@ import {
 } from '../helpers';
 import AutosuggestApp, {
   onChange,
-  onSuggestionSelected
+  onSuggestionSelected,
+  onSuggestionFocused
 } from './AutosuggestApp';
 
 describe('Autosuggest with highlightFirstSuggestion={true}', () => {
@@ -142,6 +143,18 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
         sectionIndex: null,
         method: 'enter'
       });
+    });
+  });
+
+  describe('onSuggestionFocused', () => {
+    beforeEach(() => {
+      onSuggestionFocused.reset();
+      focusAndSetInputValue('p');
+    });
+
+    it('should be called once with the right paramter when the first suggestion is autohighlighted', () => {
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Perl', year: 1987 } });
     });
   });
 });

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -20,7 +20,7 @@ import {
 import AutosuggestApp, {
   onChange,
   onSuggestionSelected,
-  onSuggestionFocused
+  onSuggestionHighlighted
 } from './AutosuggestApp';
 
 describe('Autosuggest with highlightFirstSuggestion={true}', () => {
@@ -146,15 +146,17 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
     });
   });
 
-  describe('onSuggestionFocused', () => {
+  describe('onSuggestionHighlighted', () => {
     beforeEach(() => {
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       focusAndSetInputValue('p');
     });
 
     it('should be called once with the right paramter when the first suggestion is autohighlighted', () => {
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Perl', year: 1987 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Perl', year: 1987 }
+      });
     });
   });
 });

--- a/test/multi-section/AutosuggestApp.js
+++ b/test/multi-section/AutosuggestApp.js
@@ -54,7 +54,7 @@ export const onSuggestionsClearRequested = sinon.spy(() => {
 
 export const onSuggestionSelected = sinon.spy();
 
-export const onSuggestionFocused = sinon.spy();
+export const onSuggestionHighlighted = sinon.spy();
 
 export const renderSectionTitle = sinon.spy(section => {
   return <strong>{section.title}</strong>;
@@ -108,7 +108,7 @@ export default class AutosuggestApp extends Component {
           onSuggestionsFetchRequested={onSuggestionsFetchRequested}
           onSuggestionsClearRequested={onSuggestionsClearRequested}
           onSuggestionSelected={onSuggestionSelected}
-          onSuggestionFocused={onSuggestionFocused}
+          onSuggestionHighlighted={onSuggestionHighlighted}
           getSuggestionValue={getSuggestionValue}
           renderSuggestion={renderSuggestion}
           inputProps={inputProps}

--- a/test/multi-section/AutosuggestApp.js
+++ b/test/multi-section/AutosuggestApp.js
@@ -54,6 +54,8 @@ export const onSuggestionsClearRequested = sinon.spy(() => {
 
 export const onSuggestionSelected = sinon.spy();
 
+export const onSuggestionFocused = sinon.spy();
+
 export const renderSectionTitle = sinon.spy(section => {
   return <strong>{section.title}</strong>;
 });
@@ -106,6 +108,7 @@ export default class AutosuggestApp extends Component {
           onSuggestionsFetchRequested={onSuggestionsFetchRequested}
           onSuggestionsClearRequested={onSuggestionsClearRequested}
           onSuggestionSelected={onSuggestionSelected}
+          onSuggestionFocused={onSuggestionFocused}
           getSuggestionValue={getSuggestionValue}
           renderSuggestion={renderSuggestion}
           inputProps={inputProps}

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -26,7 +26,7 @@ import {
 import AutosuggestApp, {
   onSuggestionsFetchRequested,
   onSuggestionSelected,
-  onSuggestionFocused,
+  onSuggestionHighlighted,
   renderSectionTitle,
   getSectionSuggestions,
   setHighlightFirstSuggestion
@@ -87,31 +87,37 @@ describe('Autosuggest with multiSection={true}', () => {
     });
   });
 
-  describe('onSuggestionFocused', () => {
+  describe('onSuggestionHighlighted', () => {
     beforeEach(() => {
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       focusAndSetInputValue('c');
     });
 
     it('should be called with the right paramter when Down is pressed', () => {
       clickDown();
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'C', year: 1972 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'C', year: 1972 }
+      });
     });
 
     it('should be called with the right parameter when Up is pressed', () => {
       clickUp();
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Clojure', year: 2007 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Clojure', year: 2007 }
+      });
     });
 
     it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
       clickDown();
       clickDown();
       clickDown();
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       clickUp();
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'C#', year: 2000 } });
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'C#', year: 2000 }
+      });
     });
   });
 

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -18,6 +18,7 @@ import {
   clickEscape,
   clickEnter,
   clickDown,
+  clickUp,
   setInputValue,
   focusAndSetInputValue,
   clickClearButton
@@ -25,6 +26,7 @@ import {
 import AutosuggestApp, {
   onSuggestionsFetchRequested,
   onSuggestionSelected,
+  onSuggestionFocused,
   renderSectionTitle,
   getSectionSuggestions,
   setHighlightFirstSuggestion
@@ -82,6 +84,34 @@ describe('Autosuggest with multiSection={true}', () => {
           sectionIndex: 2
         })
       );
+    });
+  });
+
+  describe('onSuggestionFocused', () => {
+    beforeEach(() => {
+      onSuggestionFocused.reset();
+      focusAndSetInputValue('c');
+    });
+
+    it('should be called with the right paramter when Down is pressed', () => {
+      clickDown();
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'C', year: 1972 } });
+    });
+
+    it('should be called with the right parameter when Up is pressed', () => {
+      clickUp();
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Clojure', year: 2007 } });
+    });
+
+    it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
+      clickDown();
+      clickDown();
+      clickDown();
+      onSuggestionFocused.reset();
+      clickUp();
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'C#', year: 2000 } });
     });
   });
 

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -88,12 +88,9 @@ describe('Autosuggest with multiSection={true}', () => {
   });
 
   describe('onSuggestionHighlighted', () => {
-    beforeEach(() => {
-      onSuggestionHighlighted.reset();
-      focusAndSetInputValue('c');
-    });
-
     it('should be called once with the suggestion that becomes highlighted', () => {
+      focusAndSetInputValue('c');
+      onSuggestionHighlighted.reset();
       clickDown();
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
@@ -102,7 +99,9 @@ describe('Autosuggest with multiSection={true}', () => {
     });
 
     it('should be called once with null when there is no more highlighted suggestion', () => {
-      clickDown()
+      focusAndSetInputValue('c');
+      clickDown();
+      onSuggestionHighlighted.reset();
       clickUp();
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -93,7 +93,7 @@ describe('Autosuggest with multiSection={true}', () => {
       focusAndSetInputValue('c');
     });
 
-    it('should be called with the right paramter when Down is pressed', () => {
+    it('should be called once with the suggestion that becomes highlighted', () => {
       clickDown();
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
@@ -101,22 +101,12 @@ describe('Autosuggest with multiSection={true}', () => {
       });
     });
 
-    it('should be called with the right parameter when Up is pressed', () => {
+    it('should be called once with null when there is no more highlighted suggestion', () => {
+      clickDown()
       clickUp();
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Clojure', year: 2007 }
-      });
-    });
-
-    it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
-      clickDown();
-      clickDown();
-      clickDown();
-      onSuggestionHighlighted.reset();
-      clickUp();
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'C#', year: 2000 }
+        suggestion: null
       });
     });
   });

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -62,6 +62,10 @@ export const onSuggestionSelected = sinon.spy(() => {
   addEvent('onSuggestionSelected');
 });
 
+export const onSuggestionFocused = sinon.spy(() => {
+  addEvent('onSuggestionFocused');
+});
+
 export default class AutosuggestApp extends Component {
   constructor() {
     super();
@@ -98,6 +102,7 @@ export default class AutosuggestApp extends Component {
         onSuggestionsFetchRequested={onSuggestionsFetchRequested}
         onSuggestionsClearRequested={onSuggestionsClearRequested}
         onSuggestionSelected={onSuggestionSelected}
+        onSuggestionFocused={onSuggestionFocused}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -62,8 +62,8 @@ export const onSuggestionSelected = sinon.spy(() => {
   addEvent('onSuggestionSelected');
 });
 
-export const onSuggestionFocused = sinon.spy(() => {
-  addEvent('onSuggestionFocused');
+export const onSuggestionHighlighted = sinon.spy(() => {
+  addEvent('onSuggestionHighlighted');
 });
 
 export default class AutosuggestApp extends Component {
@@ -102,7 +102,7 @@ export default class AutosuggestApp extends Component {
         onSuggestionsFetchRequested={onSuggestionsFetchRequested}
         onSuggestionsClearRequested={onSuggestionsClearRequested}
         onSuggestionSelected={onSuggestionSelected}
-        onSuggestionFocused={onSuggestionFocused}
+        onSuggestionHighlighted={onSuggestionHighlighted}
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -606,54 +606,18 @@ describe('Default Autosuggest', () => {
       clearEvents();
       clickSuggestion(1);
       expect(
-        getEvents().filter(event => event !== 'onSuggestionHighlighted')
+        getEvents().filter(event => event === 'onChange' || event === 'onSuggestionSelected')
       ).to.deep.equal(['onChange', 'onSuggestionSelected']);
     });
   });
 
   describe('onSuggestionHighlighted', () => {
     beforeEach(() => {
-      onSuggestionHighlighted.reset();
       focusAndSetInputValue('j');
-    });
-
-    it('should be called once with the right parameter when first Down is pressed', () => {
-      clickDown();
-      expect(onSuggestionHighlighted).to.have.been.calledOnce;
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Java', year: 1995 }
-      });
-    });
-
-    it('should be called with the right parameter when Up is pressed', () => {
-      clickUp();
-      expect(onSuggestionHighlighted).to.have.been.calledOnce;
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Javascript', year: 1995 }
-      });
-    });
-
-    it('should be called with null value when no suggestion is highlighted', () => {
-      clickDown();
-      clickDown();
       onSuggestionHighlighted.reset();
-      clickDown();
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: null
-      });
     });
 
-    it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
-      clickDown();
-      clickDown();
-      onSuggestionHighlighted.reset();
-      clickUp();
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Java', year: 1995 }
-      });
-    });
-
-    it('should be called with the right parameter when mouse enters the first suggestion', () => {
+    it('should be called once with the highlighted suggestion when mouse enters a suggestion', () => {
       mouseEnterSuggestion(0);
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
@@ -661,15 +625,7 @@ describe('Default Autosuggest', () => {
       });
     });
 
-    it('should be called with the right parameter when mouse enters', () => {
-      mouseEnterSuggestion(1);
-      expect(onSuggestionHighlighted).to.have.been.calledOnce;
-      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Javascript', year: 1995 }
-      });
-    });
-
-    it('should be called with null value when mouse leaves', () => {
+    it('should be called once with null when mouse leaves a suggestion and there is no more highlighted suggestion', () => {
       mouseEnterSuggestion(0);
       onSuggestionHighlighted.reset();
       mouseLeaveSuggestion(0);

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -38,7 +38,8 @@ import AutosuggestApp, {
   shouldRenderSuggestions,
   onSuggestionsFetchRequested,
   onSuggestionsClearRequested,
-  onSuggestionSelected
+  onSuggestionSelected,
+  onSuggestionFocused
 } from './AutosuggestApp';
 
 describe('Default Autosuggest', () => {
@@ -604,7 +605,62 @@ describe('Default Autosuggest', () => {
       onChange.reset();
       clearEvents();
       clickSuggestion(1);
-      expect(getEvents()).to.deep.equal(['onChange', 'onSuggestionSelected']);
+      expect(getEvents().filter(event => event !== 'onSuggestionFocused')).to.deep.equal(['onChange', 'onSuggestionSelected']);
+    });
+  });
+
+  describe('onSuggestionFocused', () => {
+    beforeEach(() => {
+      onSuggestionFocused.reset();
+      focusAndSetInputValue('j');
+    });
+
+    it('should be called once with the right parameter when first Down is pressed', () => {
+      clickDown();
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+    });
+
+    it('should be called with the right parameter when Up is pressed', () => {
+      clickUp();
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Javascript', year: 1995 } });
+    });
+
+    it('should be called with null value when no suggestion is highlighted', () => {
+      clickDown();
+      clickDown();
+      onSuggestionFocused.reset();
+      clickDown();
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: null });
+    });
+
+    it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
+      clickDown();
+      clickDown();
+      onSuggestionFocused.reset();
+      clickUp();
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+    });
+
+    it('should be called with the right parameter when mouse enters the first suggestion', () => {
+      mouseEnterSuggestion(0);
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+    });
+
+    it('should be called with the right parameter when mouse enters', () => {
+      mouseEnterSuggestion(1);
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Javascript', year: 1995 } });
+    });
+
+    it('should be called with null value when mouse leaves', () => {
+      mouseEnterSuggestion(0);
+      onSuggestionFocused.reset();
+      mouseLeaveSuggestion(0);
+      expect(onSuggestionFocused).to.have.been.calledOnce;
+      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: null });
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -39,7 +39,7 @@ import AutosuggestApp, {
   onSuggestionsFetchRequested,
   onSuggestionsClearRequested,
   onSuggestionSelected,
-  onSuggestionFocused
+  onSuggestionHighlighted
 } from './AutosuggestApp';
 
 describe('Default Autosuggest', () => {
@@ -605,62 +605,78 @@ describe('Default Autosuggest', () => {
       onChange.reset();
       clearEvents();
       clickSuggestion(1);
-      expect(getEvents().filter(event => event !== 'onSuggestionFocused')).to.deep.equal(['onChange', 'onSuggestionSelected']);
+      expect(
+        getEvents().filter(event => event !== 'onSuggestionHighlighted')
+      ).to.deep.equal(['onChange', 'onSuggestionSelected']);
     });
   });
 
-  describe('onSuggestionFocused', () => {
+  describe('onSuggestionHighlighted', () => {
     beforeEach(() => {
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       focusAndSetInputValue('j');
     });
 
     it('should be called once with the right parameter when first Down is pressed', () => {
       clickDown();
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Java', year: 1995 }
+      });
     });
 
     it('should be called with the right parameter when Up is pressed', () => {
       clickUp();
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Javascript', year: 1995 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Javascript', year: 1995 }
+      });
     });
 
     it('should be called with null value when no suggestion is highlighted', () => {
       clickDown();
       clickDown();
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       clickDown();
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: null });
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: null
+      });
     });
 
     it('should be called with the right parameter when a combination of Up and Down is pressed', () => {
       clickDown();
       clickDown();
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       clickUp();
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Java', year: 1995 }
+      });
     });
 
     it('should be called with the right parameter when mouse enters the first suggestion', () => {
       mouseEnterSuggestion(0);
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Java', year: 1995 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Java', year: 1995 }
+      });
     });
 
     it('should be called with the right parameter when mouse enters', () => {
       mouseEnterSuggestion(1);
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: { name: 'Javascript', year: 1995 } });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: { name: 'Javascript', year: 1995 }
+      });
     });
 
     it('should be called with null value when mouse leaves', () => {
       mouseEnterSuggestion(0);
-      onSuggestionFocused.reset();
+      onSuggestionHighlighted.reset();
       mouseLeaveSuggestion(0);
-      expect(onSuggestionFocused).to.have.been.calledOnce;
-      expect(onSuggestionFocused).to.have.been.calledWithExactly({ suggestion: null });
+      expect(onSuggestionHighlighted).to.have.been.calledOnce;
+      expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
+        suggestion: null
+      });
     });
   });
 


### PR DESCRIPTION
Resolves #168 

Added `onSuggestionFocused` prop (optional).

The function signature looks like the following:

```js
function onSuggestionFocused({ suggestion })
```

The function gets called every time focused suggestion changes.
When unfocused, the function will be called with `{ suggestion: null }`.
