### PR TITLE
React 15.5.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prepublish": "npm run dist && npm run standalone"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react-autowhatever": "^9.1.0",
     "shallow-equal": "^1.0.0"
   },

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shallowEqualArrays from 'shallow-equal/arrays';
 import Autowhatever from 'react-autowhatever';
 import { defaultTheme, mapToAutowhateverTheme } from './theme';

--- a/test/always-render-suggestions/AutosuggestApp.test.js
+++ b/test/always-render-suggestions/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import {
   init,
   expectInputValue,

--- a/test/async-suggestions/AutosuggestApp.test.js
+++ b/test/async-suggestions/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import {
   init,
   tick,

--- a/test/do-not-focus-input-on-suggestion-click/AutosuggestApp.test.js
+++ b/test/do-not-focus-input-on-suggestion-click/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import {
   init,

--- a/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion-clear-on-enter/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import {
   init,

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import {
   init,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import SyntheticEvent from 'react-dom/lib/SyntheticEvent';
-import TestUtils, { Simulate } from 'react-addons-test-utils';
+import TestUtils, { Simulate } from 'react-dom/test-utils';
 
 chai.use(sinonChai);
 

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import {
   init,

--- a/test/render-input-component/AutosuggestApp.test.js
+++ b/test/render-input-component/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import {
   init,
   expectInputAttribute,

--- a/test/render-suggestions-container/AutosuggestApp.test.js
+++ b/test/render-suggestions-container/AutosuggestApp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
 import {
   init,


### PR DESCRIPTION
This should prevent deprecation warnings from being thrown when React 15.5.0 is used. A warning is displayed when running `npm run test` but I suspect that this is due to a dependency (mocha, perhaps?) rather than due to an introduction in this PR.
