### PR TITLE
Add `reason` to `onSuggestionsFetchRequested`

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,18 @@ const suggestions = [
 This function will be called every time you need to update [`suggestions`](#suggestionsProp). It has the following signature:
 
 ```js
-function onSuggestionsFetchRequested({ value })
+function onSuggestionsFetchRequested({ value, reason })
 ```
 
-where `value` is current value of the input.
+where
+
+ - `value` is current value of the input.
+ -  `reason` is one of the following values: 
+   - 'escape-pressed' 
+   - 'input-changed' 
+   - 'input-focused'
+   - 'suggestions-revealed'
+   - 'suggestion-selected'
 
 <a name="onSuggestionsClearRequestedProp"></a>
 #### onSuggestionsClearRequested (required unless `alwaysRenderSuggestions={true}`)

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -324,7 +324,10 @@ export default class Autosuggest extends Component {
     onSuggestionSelected && onSuggestionSelected(event, data);
 
     if (alwaysRenderSuggestions) {
-      onSuggestionsFetchRequested({ value: data.suggestionValue });
+      onSuggestionsFetchRequested({
+        value: data.suggestionValue,
+        reason: 'suggestion-selected'
+      });
     } else {
       this.onSuggestionsClearRequested();
     }
@@ -465,7 +468,7 @@ export default class Autosuggest extends Component {
           onFocus && onFocus(event);
 
           if (shouldRender) {
-            onSuggestionsFetchRequested({ value });
+            onSuggestionsFetchRequested({ value, reason: 'input-focused' });
           }
         }
       },
@@ -496,7 +499,7 @@ export default class Autosuggest extends Component {
         });
 
         if (shouldRender) {
-          onSuggestionsFetchRequested({ value });
+          onSuggestionsFetchRequested({ value, reason: 'input-changed' });
         } else {
           this.onSuggestionsClearRequested();
         }
@@ -507,7 +510,10 @@ export default class Autosuggest extends Component {
           case 'ArrowUp':
             if (isCollapsed) {
               if (shouldRenderSuggestions(value)) {
-                onSuggestionsFetchRequested({ value });
+                onSuggestionsFetchRequested({
+                  value,
+                  reason: 'suggestions-revealed'
+                });
                 this.revealSuggestions();
               }
             } else if (suggestions.length > 0) {
@@ -603,7 +609,10 @@ export default class Autosuggest extends Component {
                 this.maybeCallOnChange(event, newValue, 'escape');
 
                 if (shouldRenderSuggestions(newValue)) {
-                  onSuggestionsFetchRequested({ value: newValue });
+                  onSuggestionsFetchRequested({
+                    value: newValue,
+                    reason: 'escape-pressed'
+                  });
                 } else {
                   this.onSuggestionsClearRequested();
                 }

--- a/test/multi-section/AutosuggestApp.test.js
+++ b/test/multi-section/AutosuggestApp.test.js
@@ -91,7 +91,8 @@ describe('Autosuggest with multiSection={true}', () => {
       focusInput();
       expect(onSuggestionsFetchRequested).to.have.been.calledOnce;
       expect(onSuggestionsFetchRequested).to.have.been.calledWithExactly({
-        value: ''
+        value: '',
+        reason: 'input-focused'
       });
     });
 
@@ -101,7 +102,8 @@ describe('Autosuggest with multiSection={true}', () => {
       clickEscape();
       expect(onSuggestionsFetchRequested).to.have.been.calledOnce;
       expect(onSuggestionsFetchRequested).to.have.been.calledWithExactly({
-        value: ''
+        value: '',
+        reason: 'escape-pressed'
       });
     });
   });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -615,7 +615,8 @@ describe('Default Autosuggest', () => {
       setInputValue('j');
       expect(onSuggestionsFetchRequested).to.have.been.calledOnce;
       expect(onSuggestionsFetchRequested).to.have.been.calledWithExactly({
-        value: 'j'
+        value: 'j',
+        reason: 'input-changed'
       });
     });
 
@@ -626,7 +627,8 @@ describe('Default Autosuggest', () => {
       clickDown();
       expect(onSuggestionsFetchRequested).to.have.been.calledOnce;
       expect(onSuggestionsFetchRequested).to.have.been.calledWithExactly({
-        value: 'Javascript'
+        value: 'Javascript',
+        reason: 'suggestions-revealed'
       });
     });
 


### PR DESCRIPTION
Supplies a reason to the onSuggestionsFetchRequested to give the consumer more understanding on why this has been requested.

Fixes #382 