### PR TITLE
Suggestions will hide when input combined character on IE

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -561,6 +561,9 @@ export default class Autosuggest extends Component {
             break;
 
           case 'Enter': {
+            // Ignore enter of combined character
+            if (event.keyCode === 229) break;
+
             const highlightedSuggestion = this.getHighlightedSuggestion();
 
             if (isOpen && !alwaysRenderSuggestions) {

--- a/test/always-render-suggestions/AutosuggestApp.test.js
+++ b/test/always-render-suggestions/AutosuggestApp.test.js
@@ -11,6 +11,7 @@ import {
   blurInput,
   clickEscape,
   clickEnter,
+  clickCombinedCharacterEnter,
   clickDown,
   clickUp,
   focusAndSetInputValue
@@ -104,6 +105,11 @@ describe('Autosuggest with alwaysRenderSuggestions={true}', () => {
 
     it('should not hide suggestions if there is no highlighted suggestion', () => {
       clickEnter();
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+    });
+
+    it('should not hide suggestions if enter event for combined character', () => {
+      clickCombinedCharacterEnter();
       expectSuggestions(['Perl', 'PHP', 'Python']);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -216,6 +216,11 @@ export const clickEnter = () => {
   clock.tick(1);
 };
 
+export const clickCombinedCharacterEnter = () => {
+  Simulate.keyDown(input, { key: 'Enter', keyCode: 229 });
+  clock.tick(1);
+};
+
 export const clickDown = (count = 1) => {
   for (let i = 0; i < count; i++) {
     Simulate.keyDown(input, { key: 'ArrowDown' });


### PR DESCRIPTION
I tried input Japanese(Kanji) on IE 11. But suggestions hide when enter key press.

For combine character, Should ignore `keyCode=229` in onKeyDown.
