### PR TITLE
Convert non-string values to empty strings so that trim() doesn’t throw a TypeError

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -5,7 +5,11 @@ import Autowhatever from 'react-autowhatever';
 import { defaultTheme, mapToAutowhateverTheme } from './theme';
 
 const alwaysTrue = () => true;
-const defaultShouldRenderSuggestions = value => value.trim().length > 0;
+const defaultShouldRenderSuggestions = value => {
+  const formattedValue = typeof value === 'string' ? value.trim() : '';
+
+  return formattedValue.length > 0;
+};
 const defaultRenderSuggestionsContainer = ({ containerProps, children }) =>
   <div {...containerProps}>{children}</div>;
 
@@ -426,8 +430,10 @@ export default class Autosuggest extends Component {
     const { inputProps } = this.props;
     const { value } = inputProps;
     const { valueBeforeUpDown } = this.state;
+    const query = valueBeforeUpDown || value;
+    const formattedQuery = typeof query === 'string' ? query.trim() : '';
 
-    return (valueBeforeUpDown || value).trim();
+    return formattedQuery;
   }
 
   renderSuggestionsContainer = ({ containerProps, children }) => {

--- a/test/handle-null-value/AutosuggestApp.js
+++ b/test/handle-null-value/AutosuggestApp.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autosuggest from '../../src/Autosuggest';
+import languages from '../plain-list/languages';
+import { escapeRegexCharacters } from '../../demo/src/components/utils/utils.js';
+
+const getMatchingLanguages = value => {
+  const escapedValue = escapeRegexCharacters(value.trim());
+  const regex = new RegExp('^' + escapedValue, 'i');
+
+  return languages.filter(language => regex.test(language.name));
+};
+
+let app = null;
+
+const onChange = (event, { newValue }) => {
+  app.setState({
+    value: newValue
+  });
+};
+
+const onSuggestionsFetchRequested = ({ value }) => {
+  app.setState({
+    suggestions: getMatchingLanguages(value)
+  });
+};
+
+const onSuggestionsClearRequested = () => {
+  app.setState({
+    suggestions: []
+  });
+};
+
+const getSuggestionValue = suggestion => suggestion.name;
+
+const renderSuggestion = suggestion => suggestion.name;
+
+export const renderSuggestionsContainer = sinon.spy(
+  ({ containerProps, children, query }) =>
+    <div {...containerProps}>
+      {children}
+      <div className="my-suggestions-container-footer">
+        Press Enter to search <strong className="my-query">{query}</strong>
+      </div>
+    </div>
+);
+
+export default class AutosuggestApp extends Component {
+  constructor() {
+    super();
+
+    app = this;
+
+    this.state = {
+      value: null,
+      suggestions: []
+    };
+  }
+
+  storeAutosuggestReference = autosuggest => {
+    if (autosuggest !== null) {
+      this.input = autosuggest.input;
+    }
+  };
+
+  render() {
+    const { value, suggestions } = this.state;
+    const inputProps = {
+      value,
+      onChange
+    };
+
+    return (
+      <Autosuggest
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        renderSuggestionsContainer={renderSuggestionsContainer}
+        inputProps={inputProps}
+        ref={this.storeAutosuggestReference}
+      />
+    );
+  }
+}

--- a/test/handle-null-value/AutosuggestApp.test.js
+++ b/test/handle-null-value/AutosuggestApp.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  getInnerHTML,
+  getElementWithClass,
+  setInputValue
+} from '../helpers';
+import AutosuggestApp from './AutosuggestApp';
+
+describe('Autosuggest receiving null in this.state.value', () => {
+  beforeEach(() => {
+    init(TestUtils.renderIntoDocument(<AutosuggestApp />));
+  });
+
+  it('should convert null to an empty string in order to avoid TypeErrors', () => {
+    setInputValue(null);
+    expect(getInnerHTML(getElementWithClass('my-query'))).to.equal('');
+  });
+});


### PR DESCRIPTION
When null values are passed into the Autosuggest component's state I receive a TypeError originating from one of the two functions where the String.prototype.trim() method is used (defaultShouldRenderSuggestions and getQuery). My PR provides both functions with type checking and a fallback empty string to make sure the value being trimmed is a string.

Relevant issues: 
https://github.com/moroshko/react-autosuggest/issues/368

* npm run build was completed successfully