### PR TITLE
Fix the keydown handling in old browsers

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -525,7 +525,8 @@ export default class Autosuggest extends Component {
         }
       },
       onKeyDown: (event, data) => {
-        switch (event.key) {
+        const keyCode = event.key || event.code;
+        switch (keyCode) {
           case 'ArrowDown':
           case 'ArrowUp':
             if (isCollapsed) {


### PR DESCRIPTION
Fixes the keyboard operation in many old browsers, tested in Chrome 48.
See https://github.com/moroshko/react-autosuggest/issues/406 for details
