### PR TITLE
fix suggestion stay open on right mouse click

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -6,10 +6,9 @@ import { defaultTheme, mapToAutowhateverTheme } from './theme';
 
 const alwaysTrue = () => true;
 const defaultShouldRenderSuggestions = value => value.trim().length > 0;
-const defaultRenderSuggestionsContainer = ({ containerProps, children }) =>
-  <div {...containerProps}>
-    {children}
-  </div>;
+const defaultRenderSuggestionsContainer = ({ containerProps, children }) => (
+  <div {...containerProps}>{children}</div>
+);
 
 export default class Autosuggest extends Component {
   static propTypes = {
@@ -260,6 +259,14 @@ export default class Autosuggest extends Component {
 
   onDocumentMouseDown = event => {
     this.justClickedOnSuggestionsContainer = false;
+    if (
+      this.suggestionsContainer &&
+      !this.suggestionsContainer.contains(event.target) &&
+      this.justSelectedSuggestion
+    ) {
+      this.input.focus();
+      this.justSelectedSuggestion = false;
+    }
 
     let node =
       (event.detail && event.detail.target) || // This is for testing only. Please show me a better way to emulate this.


### PR DESCRIPTION
#436 
#224 
I did add to `onDocumentMouseDown` a piece of code that checks whether the mouse click in boundaries of the main autosuggest container or not. Can't be sure if it's a reasonable idea or not to force to focus on input. Unfortunately didn't find another way how to fix it because when there some click on the suggestion list and it's not left click of the mouse it just locks `justSelectedSuggestion` as I understood.   
Thanks! 