### PR TITLE
Hotfix - Cannot read property 'trim' of undefined

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -427,7 +427,7 @@ export default class Autosuggest extends Component {
     const { value } = inputProps;
     const { valueBeforeUpDown } = this.state;
 
-    return (valueBeforeUpDown || value).trim();
+    return (valueBeforeUpDown || value || '').trim();
   }
 
   renderSuggestionsContainer = ({ containerProps, children }) => {


### PR DESCRIPTION
When both values are null or undefined, the script breaks the code and cause "TypeError: Cannot read property 'trim' of undefined"