### PR TITLE
Add onSuggestionClick interceptor function to specify custom behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ class Example extends React.Component {
 | [`getSuggestionValue`](#getSuggestionValueProp) | Function | ✓ | Implement it to teach Autosuggest what should be the input value when suggestion is clicked. |
 | [`renderSuggestion`](#renderSuggestionProp) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#inputPropsProp) | Object | ✓ | Pass through arbitrary props to the input. It must contain at least `value` and `onChange`. |
+| [`onSuggestionClick`](#onSuggestionClickProp) | Function | | If specified, will be called whenever a suggestion is clicked. |
 | [`onSuggestionSelected`](#onSuggestionSelectedProp) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
 | [`onSuggestionHighlighted`](#onSuggestionHighlightedProp) | Function | | Will be called every time the highlighted suggestion changes. |
 | [`shouldRenderSuggestions`](#shouldRenderSuggestionsProp) | Function | | When the input is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
@@ -353,6 +354,41 @@ function onBlur(event, { highlightedSuggestion })
 where:
 
 * `highlightedSuggestion` - the suggestion that was highlighted just before the input lost focus, or `null` if there was no highlighted suggestion.
+
+<a name="onSuggestionClickProp"></a>
+#### onSuggestionClick (optional)
+
+This function is called when a suggestion is clicked.  It allows you to intercept, and decide whether or not to select this suggestion, and specify custom behavior on click. It has the following signature:
+
+```js
+function onSuggestionSelected(event, { selectSuggestion, suggestion, suggestionValue, suggestionIndex, sectionIndex, method })
+```
+
+where:
+
+* `selectSuggestion` - a callback to proceed with the selection of the suggestion, if this is not called, the suggestion will not be selected
+* `suggestion` - the selected suggestion
+* `suggestionValue` - the value of the selected suggestion (equivalent to `getSuggestionValue(suggestion)`)
+* `suggestionIndex` - the index of the selected suggestion in the `suggestions` array
+* `sectionIndex` - when rendering [multiple sections](#multiSectionProp), this will be the section index (in [`suggestions`](#suggestionsProp)) of the selected suggestion. Otherwise, it will be `null`.
+* `method` - string describing how user selected the suggestion. The possible values are:
+  * `'click'` - user clicked (or tapped) on the suggestion
+  * `'enter'` - user selected the suggestion using <kbd>Enter</kbd>
+  
+You can do something like this:
+
+```js
+const onSuggestionClick = (event, {selectSuggestion, suggestionValue}) => {
+  // only select the suggestion if it meets your criteria
+  if (suggestionValue !== 'SOME VALUE') {
+    return selectSuggestion();
+  }
+};
+
+<Autosuggest
+  onSuggestionClick={onSuggestionClick}
+/>
+```
 
 <a name="onSuggestionSelectedProp"></a>
 #### onSuggestionSelected (optional)

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -34,6 +34,7 @@ export default class Autosuggest extends Component {
         );
       }
     },
+    onSuggestionClick: PropTypes.func,
     onSuggestionSelected: PropTypes.func,
     onSuggestionHighlighted: PropTypes.func,
     renderInputComponent: PropTypes.func,
@@ -376,7 +377,11 @@ export default class Autosuggest extends Component {
   };
 
   onSuggestionClick = event => {
-    const { alwaysRenderSuggestions, focusInputOnSuggestionClick } = this.props;
+    const {
+      alwaysRenderSuggestions,
+      focusInputOnSuggestionClick,
+      onSuggestionClick
+    } = this.props;
     const { sectionIndex, suggestionIndex } = this.getSuggestionIndices(
       this.findSuggestionElement(event.target)
     );
@@ -384,29 +389,40 @@ export default class Autosuggest extends Component {
     const clickedSuggestionValue = this.props.getSuggestionValue(
       clickedSuggestion
     );
-
-    this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
-    this.onSuggestionSelected(event, {
+    const suggestionData = {
       suggestion: clickedSuggestion,
       suggestionValue: clickedSuggestionValue,
       suggestionIndex: suggestionIndex,
       sectionIndex,
       method: 'click'
-    });
+    };
+    const next = () => {
+      this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
+      this.onSuggestionSelected(event, suggestionData);
 
-    if (!alwaysRenderSuggestions) {
-      this.closeSuggestions();
-    }
+      if (!alwaysRenderSuggestions) {
+        this.closeSuggestions();
+      }
 
-    if (focusInputOnSuggestionClick === true) {
-      this.input.focus();
+      if (focusInputOnSuggestionClick === true) {
+        this.input.focus();
+      } else {
+        this.onBlur();
+      }
+
+      setTimeout(() => {
+        this.justSelectedSuggestion = false;
+      });
+    };
+
+    if (onSuggestionClick) {
+      onSuggestionClick(event, {
+        ...suggestionData,
+        selectSuggestion: () => next()
+      });
     } else {
-      this.onBlur();
+      next();
     }
-
-    setTimeout(() => {
-      this.justSelectedSuggestion = false;
-    });
   };
 
   onBlur = () => {

--- a/test/intercept-on-suggestion-click/AutosuggestApp.js
+++ b/test/intercept-on-suggestion-click/AutosuggestApp.js
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autosuggest from '../../src/Autosuggest';
+import languages from '../plain-list/languages';
+import { escapeRegexCharacters } from '../../demo/src/components/utils/utils.js';
+
+const getMatchingLanguages = value => {
+  const escapedValue = escapeRegexCharacters(value.trim());
+  const regex = new RegExp('^' + escapedValue, 'i');
+
+  return languages.filter(language => regex.test(language.name));
+};
+
+let app = null;
+
+export const getSuggestionValue = sinon.spy(suggestion => {
+  return suggestion.name;
+});
+
+export const renderSuggestion = sinon.spy(suggestion => {
+  return <span>{suggestion.name}</span>;
+});
+
+export const onChange = sinon.spy((event, { newValue }) => {
+  app.setState({
+    value: newValue
+  });
+});
+
+export const onBlur = sinon.spy();
+
+export const onSuggestionsFetchRequested = sinon.spy(({ value }) => {
+  app.setState({
+    suggestions: getMatchingLanguages(value)
+  });
+});
+
+export const onSuggestionsClearRequested = sinon.spy(() => {
+  app.setState({
+    suggestions: []
+  });
+});
+
+export const onSuggestionSelected = sinon.spy();
+
+export const onSuggestionClick = sinon.spy(
+  (event, { selectSuggestion, suggestionValue }) => {
+    const toMatch = getMatchingLanguages('p')[1].name;
+
+    if (suggestionValue !== toMatch) {
+      selectSuggestion();
+    }
+  }
+);
+
+export default class AutosuggestApp extends Component {
+  constructor() {
+    super();
+
+    app = this;
+
+    this.state = {
+      value: '',
+      suggestions: []
+    };
+  }
+
+  render() {
+    const { value, suggestions } = this.state;
+    const inputProps = {
+      value,
+      onChange,
+      onBlur
+    };
+
+    return (
+      <Autosuggest
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        inputProps={inputProps}
+        onSuggestionSelected={onSuggestionSelected}
+        onSuggestionClick={onSuggestionClick}
+      />
+    );
+  }
+}

--- a/test/intercept-on-suggestion-click/AutosuggestApp.test.js
+++ b/test/intercept-on-suggestion-click/AutosuggestApp.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  clickSuggestion,
+  focusAndSetInputValue,
+  expectInputValue
+} from '../helpers';
+import AutosuggestApp, { onSuggestionClick } from './AutosuggestApp';
+
+describe('Autosuggest with onSuggestionClick={interceptorFunction}', () => {
+  beforeEach(() => {
+    init(TestUtils.renderIntoDocument(<AutosuggestApp />));
+  });
+
+  describe('when suggestion is clicked with click interceptor specified on clicked value', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      onSuggestionClick.reset();
+      clickSuggestion(1);
+    });
+
+    it('should call interceptor function', () => {
+      expect(onSuggestionClick).to.have.been.calledOnce;
+    });
+
+    it('input value should not be changed', () => {
+      expectInputValue('p');
+    });
+  });
+
+  describe('when suggestion is clicked with click interceptor not specified on clicked value', () => {
+    beforeEach(() => {
+      focusAndSetInputValue('p');
+      onSuggestionClick.reset();
+      clickSuggestion(2);
+    });
+
+    it('should call interceptor function', () => {
+      expect(onSuggestionClick).to.have.been.calledOnce;
+    });
+
+    it('input value should not be changed', () => {
+      expectInputValue('Python');
+    });
+  });
+});


### PR DESCRIPTION
https://github.com/moroshko/react-autosuggest/issues/503

Add the ability to perform custom behavior upon click of a suggestion.

In my case, I wanted to add some search help inline which when clicked upon, it would open a modal. I figure there could be many cases where there is a desire for finer-grained control over what happens when a suggestion is clicked. 