### PR TITLE
Allow default up / down arrow key behavior when no suggestions are available.

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -564,6 +564,8 @@ export default class Autosuggest extends Component {
                   reason: 'suggestions-revealed'
                 });
                 this.revealSuggestions();
+
+                event.preventDefault(); // Prevents the cursor from moving
               }
             } else if (suggestions.length > 0) {
               const {
@@ -596,9 +598,9 @@ export default class Autosuggest extends Component {
                 newValue,
                 keyCode === 40 ? 'down' : 'up'
               );
-            }
 
-            event.preventDefault(); // Prevents the cursor from moving
+              event.preventDefault(); // Prevents the cursor from moving
+            }
 
             this.justPressedUpDown = true;
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -233,6 +233,17 @@ describe('Default Autosuggest', () => {
       clickDown(5);
       expectHighlightedSuggestion('Perl');
     });
+
+    describe('with no matching suggestions', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('z');
+      });
+
+      it('should not show suggestions', () => {
+        clickDown();
+        expectSuggestions([]);
+      });
+    });
   });
 
   describe('when pressing Up', () => {
@@ -265,6 +276,17 @@ describe('Default Autosuggest', () => {
     it('should highlight the last suggestion again', () => {
       clickUp(5);
       expectHighlightedSuggestion('Python');
+    });
+
+    describe('with no matching suggestions', () => {
+      beforeEach(() => {
+        focusAndSetInputValue('z');
+      });
+
+      it('should not show suggestions', () => {
+        clickUp();
+        expectSuggestions([]);
+      });
     });
   });
 


### PR DESCRIPTION
This is to address Issue #517. In lieu of adding coverage around cursor positions, I've added some around expected behavior for using the <kbd>up</kbd> / <kbd>down</kbd> keys when suggestions aren't available.