### PR TITLE
Fix unwanted input focus after mouse up event on document

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -354,9 +354,9 @@ export default class Autosuggest extends Component {
 
   onDocumentMouseUp = () => {
     if (this.pressedSuggestion && !this.justSelectedSuggestion) {
-      this.pressedSuggestion = null;
       this.input.focus();
     }
+    this.pressedSuggestion = null;
   };
 
   onSuggestionMouseDown = event => {

--- a/test/do-not-focus-input-on-suggestion-click/AutosuggestApp.test.js
+++ b/test/do-not-focus-input-on-suggestion-click/AutosuggestApp.test.js
@@ -6,7 +6,8 @@ import {
   syntheticEventMatcher,
   clickSuggestion,
   focusAndSetInputValue,
-  isInputFocused
+  isInputFocused,
+  mouseUpDocument
 } from '../helpers';
 import AutosuggestApp, {
   onBlur,
@@ -39,6 +40,11 @@ describe('Autosuggest with focusInputOnSuggestionClick={false}', () => {
 
     it('should call onSuggestionsClearRequested once', () => {
       expect(onSuggestionsClearRequested).to.have.been.calledOnce;
+    });
+
+    it('should not focus input on document mouse up', () => {
+      mouseUpDocument();
+      expect(isInputFocused()).to.equal(false);
     });
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -213,6 +213,7 @@ export const clickSuggestion = suggestionIndex => {
   mouseEnterSuggestion(suggestionIndex);
   mouseDownDocument(suggestion);
   mouseDownSuggestion(suggestionIndex);
+  mouseUpDocument(suggestion);
   blurInput();
   focusInput();
   Simulate.click(suggestion);


### PR DESCRIPTION
Autosuggest didn't set `this.pressedSuggestion` to null if `this.justSelectedSuggestion` is `true`. That's is the case when we are just clicking a suggestion in the dropdown. 

I wrote a test to prevent this regression again. My first intention was to put it in `plain-list` tests section but it seems that `blurInput()` helper doesn't take effect if `focusInputOnSuggestionClick` is `true` (`isInputFocused` returns `true`) and test failed even with new changes. So I put it under `do-not-focus-input-on-suggestion-click` section where it fails without change and passes with it.

Fixes #568