### PR TITLE
Don't focus input on mouseup

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -353,8 +353,12 @@ export default class Autosuggest extends Component {
   };
 
   onDocumentMouseUp = () => {
+    const { focusInputOnSuggestionClick } = this.props;
+
     if (this.pressedSuggestion && !this.justSelectedSuggestion) {
-      this.input.focus();
+      if (focusInputOnSuggestionClick) {
+        this.input.focus();
+      }
     }
     this.pressedSuggestion = null;
   };


### PR DESCRIPTION
Thanks a lot for contributing to react-autosuggest :beers:

Before submitting the Pull Request, please:

* write a clear description of what this Pull Request is trying to achieve
* `npm run build` to see that you didn't break anything

After clicking on a suggestion, clicking anywhere else triggers onDocumentMouseUp (even after a period of time, I guess the component isn't being unmounted and thus the event listener isn't being removed). `this.justSelectedSuggest` is false / undefined which causes the input to be focussed again. This fix isn't a perfect fix, but it will prevent the input from refocusing if the `focusInputOnSuggestionClick` prop is set to false.

I've built and have this working in my project, and no changes to any tests were required.