### PR TITLE
Add containerProps property for arbitrary props on the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ class Example extends React.Component {
 | [`getSuggestionValue`](#get-suggestion-value-prop) | Function | ✓ | Implement it to teach Autosuggest what should be the input value when suggestion is clicked. |
 | [`renderSuggestion`](#render-suggestion-prop) | Function | ✓ | Use your imagination to define how suggestions are rendered. |
 | [`inputProps`](#input-props-prop) | Object | ✓ | Pass through arbitrary props to the input. It must contain at least `value` and `onChange`. |
+| [`containerProps`](#container-props-prop) | Object | | Pass through arbitrary props to the container. Useful if you need to override the default props set by Autowhatever, for example for accessibility. |
 | [`onSuggestionSelected`](#on-suggestion-selected-prop) | Function | | Will be called every time suggestion is selected via mouse or keyboard. |
 | [`onSuggestionHighlighted`](#on-suggestion-highlighted-prop) | Function | | Will be called every time the highlighted suggestion changes. |
 | [`shouldRenderSuggestions`](#should-render-suggestions-prop) | Function | | When the input is focused, Autosuggest will consult this function when to render suggestions. Use it, for example, if you want to display suggestions when input value is at least 2 characters long. |
@@ -318,6 +319,17 @@ const inputProps = {
   onBlur,         // called when the input loses focus, e.g. when user presses Tab
   type: 'search',
   placeholder: 'Enter city or postcode'
+};
+```
+<a name="container-props-prop"></a>
+#### containerProps
+
+Provides arbitrary properties to the outer `div` container of Autosuggest. Allows the override of accessibility properties.
+
+```js
+const containerProps = {
+  role: button,         // if you use Autosuggest to not allow editing of the input, then the <div> is a button that opens a list
+  dataId: 'my-data-id'
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Provides arbitrary properties to the outer `div` container of Autosuggest. Allow
 
 ```js
 const containerProps = {
-  role: button,         // if you use Autosuggest to not allow editing of the input, then the <div> is a button that opens a list
+  role: 'button',         // if you use Autosuggest to not allow editing of the input, then the <div> is a button that opens a list
   dataId: 'my-data-id'
 };
 ```

--- a/package.json
+++ b/package.json
@@ -78,14 +78,34 @@
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "lint-staged": {
-    ".*.js": ["npm run prettier", "git add"],
-    "*.js": ["npm run prettier", "git add"],
-    "demo/src/**/*.js": ["npm run prettier", "git add"],
-    "demo/standalone/app.js": ["npm run prettier", "git add"],
-    "src/**/*.js": ["npm run prettier", "git add"],
-    "test/**/*.js": ["npm run prettier", "git add"]
+    ".*.js": [
+      "npm run prettier",
+      "git add"
+    ],
+    "*.js": [
+      "npm run prettier",
+      "git add"
+    ],
+    "demo/src/**/*.js": [
+      "npm run prettier",
+      "git add"
+    ],
+    "demo/standalone/app.js": [
+      "npm run prettier",
+      "git add"
+    ],
+    "src/**/*.js": [
+      "npm run prettier",
+      "git add"
+    ],
+    "test/**/*.js": [
+      "npm run prettier",
+      "git add"
+    ]
   },
   "keywords": [
     "autosuggest",
@@ -111,10 +131,20 @@
     "branches": 91,
     "functions": 100,
     "lines": 95,
-    "include": ["src/*.js"],
-    "exclude": ["test/**/*.js"],
-    "reporter": ["lcov", "text-summary"],
-    "require": ["babel-register", "./test/setup.js"],
+    "include": [
+      "src/*.js"
+    ],
+    "exclude": [
+      "test/**/*.js"
+    ],
+    "reporter": [
+      "lcov",
+      "text-summary"
+    ],
+    "require": [
+      "babel-register",
+      "./test/setup.js"
+    ],
     "check-coverage": true
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -78,34 +78,14 @@
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "lint-staged": {
-    ".*.js": [
-      "npm run prettier",
-      "git add"
-    ],
-    "*.js": [
-      "npm run prettier",
-      "git add"
-    ],
-    "demo/src/**/*.js": [
-      "npm run prettier",
-      "git add"
-    ],
-    "demo/standalone/app.js": [
-      "npm run prettier",
-      "git add"
-    ],
-    "src/**/*.js": [
-      "npm run prettier",
-      "git add"
-    ],
-    "test/**/*.js": [
-      "npm run prettier",
-      "git add"
-    ]
+    ".*.js": ["npm run prettier", "git add"],
+    "*.js": ["npm run prettier", "git add"],
+    "demo/src/**/*.js": ["npm run prettier", "git add"],
+    "demo/standalone/app.js": ["npm run prettier", "git add"],
+    "src/**/*.js": ["npm run prettier", "git add"],
+    "test/**/*.js": ["npm run prettier", "git add"]
   },
   "keywords": [
     "autosuggest",
@@ -131,20 +111,10 @@
     "branches": 91,
     "functions": 100,
     "lines": 95,
-    "include": [
-      "src/*.js"
-    ],
-    "exclude": [
-      "test/**/*.js"
-    ],
-    "reporter": [
-      "lcov",
-      "text-summary"
-    ],
-    "require": [
-      "babel-register",
-      "./test/setup.js"
-    ],
+    "include": ["src/*.js"],
+    "exclude": ["test/**/*.js"],
+    "reporter": ["lcov", "text-summary"],
+    "require": ["babel-register", "./test/setup.js"],
     "check-coverage": true
   },
   "license": "MIT"

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -81,7 +81,8 @@ export default class Autosuggest extends Component {
     focusInputOnSuggestionClick: PropTypes.bool,
     highlightFirstSuggestion: PropTypes.bool,
     theme: PropTypes.object,
-    id: PropTypes.string
+    id: PropTypes.string,
+    containerProps: PropTypes.object
   };
 
   static defaultProps = {
@@ -515,7 +516,8 @@ export default class Autosuggest extends Component {
       theme,
       getSuggestionValue,
       alwaysRenderSuggestions,
-      highlightFirstSuggestion
+      highlightFirstSuggestion,
+      containerProps
     } = this.props;
     const {
       isFocused,
@@ -748,6 +750,7 @@ export default class Autosuggest extends Component {
         highlightedSectionIndex={highlightedSectionIndex}
         highlightedItemIndex={highlightedSuggestionIndex}
         inputProps={autowhateverInputProps}
+        containerProps={containerProps}
         itemProps={this.itemProps}
         theme={mapToAutowhateverTheme(theme)}
         id={id}


### PR DESCRIPTION
This PR adds a new property called containerProps to allow customization of props passed down to `Autowhatever`. It exposes the work done here: https://github.com/moroshko/react-autowhatever/pull/45

Hope the `README` update is enough!

Thanks