### PR TITLE
add note about onSuggestionsClearRequested in alwaysRenderSuggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ this.state = {
 };
 ```
 
+As mentioned in the [`onSuggestionsClearRequested` section](#on-suggestions-clear-requested-prop), you don't need to implement `onSuggestionsClearRequested` if you set `alwaysRenderSuggestions={true}`. If you do implement it, don't set `suggestions` to an empty array in `onSuggestionsClearRequested`, or else the suggestions will no longer be rendered.
+
 <a name="highlight-first-suggestion-prop"></a>
 #### highlightFirstSuggestion (optional)
 


### PR DESCRIPTION
clarifying this since I just ran into this. suggestions were disappearing even with `alwaysRenderSuggestions` (I was changing code that didn't use `alwaysRenderSuggestions` before, so I had a `onSuggestionsClearRequested` implementation already)