### PR TITLE
Adds note about forwarding ref on custom inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,15 +486,17 @@ To keep Autosuggest [accessible](https://rawgit.com/w3c/aria-practices/master/ar
 * render an input
 * pass through all the provided `inputProps` to the input
 
+Additionally, the rendered component requires a [forwarded ref](https://reactjs.org/docs/forwarding-refs.html) to the actual `input` component.
+
 Example:
 
 ```js
-const renderInputComponent = inputProps => (
+const renderInputComponent = React.forwardRef((inputProps, ref) => (
   <div>
-    <input {...inputProps} />
+    <input {...inputProps} ref={ref} />
     <div>custom stuff</div>
   </div>
-);
+));
 
 ```
 


### PR DESCRIPTION
Hello! Thanks for your library. We had to [add a forward ref](https://github.com/artsy/reaction/commit/ae033ae7011d4b839b6257579c03127fc2ed3df9) to get `react-autosuggest` to work with a custom input component. This PR adds this requirement to the docs in the readme. Thanks again!