### PR TITLE
added import React to Basic Usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can also use the standalone UMD build:
 ## Basic Usage
 
 ```js
+import React from 'react';
 import Autosuggest from 'react-autosuggest';
 
 // Imagine you have a list of languages that you'd like to autosuggest.


### PR DESCRIPTION
In order for the code snippet in Basic Usage to work in React, `import React from 'react';` needs to be added at the top of the file.
