### PR TITLE
Respect Existing onclick Attributes

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -283,6 +283,11 @@ export default class Autosuggest extends Component {
       event.target;
 
     while (node !== null && node !== document) {
+      if (node.onclick) {
+        // Respect existing onclick attributes
+        return node.click();
+      }
+
       if (node.getAttribute('data-suggestion-index') !== null) {
         // Suggestion was clicked
         return;


### PR DESCRIPTION
When defining an onclick attribute within an element inside of the
container or otherwise, you cannot trigger an action since the document
onmousedown event will click-jack the element and cause it never to
fire.

This change detects an existing onclick handler on an element and
instead will fire that elements click handler if it is detected.  The
main use case for this is to have a button with a custom action inside
of the container; the code could go farther to ensure it was within the
container, although, it seems that we should respect other onclick
events.