### PR TITLE
Adds propTypes validation that `inputProps` is passed.

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -43,6 +43,10 @@ export default class Autosuggest extends Component {
     inputProps: (props, propName) => {
       const inputProps = props[propName];
 
+      if (!inputProps) {
+        throw new Error("'inputProps' must be passed.");
+      }
+
       if (!Object.prototype.hasOwnProperty.call(inputProps, 'value')) {
         throw new Error("'inputProps' must have 'value'.");
       }


### PR DESCRIPTION
At the moment it blows up with this error if you don't pass any value for `inputProps`.

![image (1)](https://user-images.githubusercontent.com/9342866/70547840-e1b1c600-1b71-11ea-8272-e3e5dbc0dda4.png)

... with this PR it still blows up but you get a slightly more useful error:

![image](https://user-images.githubusercontent.com/9342866/70547927-09a12980-1b72-11ea-9850-447f2375b8ba.png)


