### PR TITLE
Fix focus state from server side rendered input

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -95,11 +95,11 @@ export default class Autosuggest extends Component {
     id: '1'
   };
 
-  constructor({ alwaysRenderSuggestions }) {
+  constructor({ alwaysRenderSuggestions, inputProps }) {
     super();
 
     this.state = {
-      isFocused: false,
+      isFocused: inputProps.autoFocus,
       isCollapsed: !alwaysRenderSuggestions,
       highlightedSectionIndex: null,
       highlightedSuggestionIndex: null,
@@ -119,6 +119,8 @@ export default class Autosuggest extends Component {
 
     this.input = this.autowhatever.input;
     this.suggestionsContainer = this.autowhatever.itemsContainer;
+
+    this.ensureFocusState();
   }
 
   // eslint-disable-next-line camelcase, react/sort-comp
@@ -169,11 +171,25 @@ export default class Autosuggest extends Component {
         });
       }
     }
+
+    this.ensureFocusState();
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.onDocumentMouseDown);
     document.removeEventListener('mouseup', this.onDocumentMouseUp);
+  }
+
+  // This works only when the `renderInputComponent` is not set. Otherwise
+  // input ref is out of react-autowhatever control.
+  ensureFocusState() {
+    if (
+      this.input &&
+      document.activeElement === this.input &&
+      !this.state.isFocused
+    ) {
+      this.setState({ isFocused: true });
+    }
   }
 
   updateHighlightedSuggestion(sectionIndex, suggestionIndex, prevValue) {
@@ -542,7 +558,6 @@ export default class Autosuggest extends Component {
           !this.justClickedOnSuggestionsContainer
         ) {
           const shouldRender = shouldRenderSuggestions(value);
-
           this.setState({
             isFocused: true,
             isCollapsed: !shouldRender

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -558,6 +558,7 @@ export default class Autosuggest extends Component {
           !this.justClickedOnSuggestionsContainer
         ) {
           const shouldRender = shouldRenderSuggestions(value);
+
           this.setState({
             isFocused: true,
             isCollapsed: !shouldRender


### PR DESCRIPTION
On 9.4.3 version, `isFocused` state param remains false when the input is focused before the onFocus listener has been initialized. So on SSR before the javascript is ready and before react hydrates server's html, there are two cases of having focused input:
a) When `autoFocus` on inputProps is true.
b) When the user focuses on then input rendered by the server.


-------

Thanks a lot for contributing to react-autosuggest :beers:

Before submitting the Pull Request, please:

* write a clear description of what this Pull Request is trying to achieve
* `npm run build` to see that you didn't break anything
