### PR TITLE
Revival

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ demo/dist
 npm-debug.log
 yarn.lock
 package-lock.json
+*.log

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-autowhatever": "^10.1.2",
+    "react-autowhatever": "^10.2.1",
     "shallow-equal": "^1.0.0"
   },
   "peerDependencies": {
@@ -65,8 +65,8 @@
     "openurl": "^1.1.1",
     "postcss-loader": "^1.3.3",
     "prettier": "1.14.2",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "react-modal": "^1.7.7",
     "react-transform-hmr": "^1.0.4",
     "sinon": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-eslint": "^7.2.3",
     "babel-loader": "^6.4.1",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.6",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.19",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,6 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import SyntheticEvent from 'react-dom/lib/SyntheticEvent';
 import TestUtils, { Simulate } from 'react-dom/test-utils';
 
 chai.use(sinonChai);
@@ -39,7 +38,19 @@ export const init = application => {
   clearButton = TestUtils.scryRenderedDOMComponentsWithTag(app, 'button')[0];
 };
 
-export const syntheticEventMatcher = sinon.match.instanceOf(SyntheticEvent);
+// Since react-dom doesn't export SyntheticEvent anymore
+export const syntheticEventMatcher = sinon.match(value => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+
+  if ('_dispatchListeners' in value && proto && proto.constructor.Interface) {
+    return true;
+  }
+  return false;
+}, 'of SyntheticEvent type');
 export const childrenMatcher = sinon.match.any;
 export const containerPropsMatcher = sinon.match({
   id: sinon.match.string,


### PR DESCRIPTION
Trying to revive this repo.

First of all `babel-plugin-transform-react-remove-prop-types` introduced a breaking change after `0.4.19` that doesn't work with babel 6 that is used in this project (for now), so I just fixed its' version to `0.4.19` until we update to babel 7.

Second of all looks like tests were falling because of #681 which introduced breaking change to the lib since older versions of `react` don't support lifecycle methods with `UNSAFE_` prefix. So we either need to change peer-dependency version or call `UNSAFE` version of the hook in `componentWillRecieveProps` to support older version (also we need to do this in https://github.com/moroshko/react-autosuggest since it's broken there too).