### PR TITLE
Update peer deps to 16.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "shallow-equal": "^1.2.1"
   },
   "peerDependencies": {
-    "react": ">=0.14.7"
+    "react": ">=16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
It should be 16.3.0 since the package will not work for older versions since 10.0.0

Thanks a lot for contributing to react-autosuggest :beers:

Before submitting the Pull Request, please:

* write a clear description of what this Pull Request is trying to achieve
* `npm run build` to see that you didn't break anything
