### PR TITLE
Features/replace event key in autowhatever

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -301,11 +301,13 @@ export default class Autowhatever extends Component {
       highlightedSectionIndex,
       highlightedItemIndex,
     } = this.props;
+    const { keyCode } = event;
 
-    switch (event.key) {
-      case 'ArrowDown':
-      case 'ArrowUp': {
-        const nextPrev = event.key === 'ArrowDown' ? 'next' : 'prev';
+    switch (keyCode) {
+      case 40: // ArrowDown
+      case 38: {
+        // ArrowUp
+        const nextPrev = keyCode === 40 ? 'next' : 'prev';
         const [
           newHighlightedSectionIndex,
           newHighlightedItemIndex,

--- a/test/autowhatever/autowhatever-helpers.js
+++ b/test/autowhatever/autowhatever-helpers.js
@@ -58,8 +58,11 @@ export const mouseDownItem = (itemIndex) =>
 
 export const clickItem = (itemIndex) => Simulate.click(getItem(itemIndex));
 
-export const clickUp = () => Simulate.keyDown(input, { key: 'ArrowUp' });
+export const clickUp = () =>
+  Simulate.keyDown(input, { key: 'ArrowUp', keyCode: 38 });
 
-export const clickDown = () => Simulate.keyDown(input, { key: 'ArrowDown' });
+export const clickDown = () =>
+  Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
 
-export const clickEnter = () => Simulate.keyDown(input, { key: 'Enter' });
+export const clickEnter = () =>
+  Simulate.keyDown(input, { key: 'Enter', keyCode: 13 });


### PR DESCRIPTION
Thanks a lot for contributing to react-autosuggest :beers:

Before submitting the Pull Request, please:

* write a clear description of what this Pull Request is trying to achieve
* `npm run build` to see that you didn't break anything

npm run build succeeded in github.

This will make react-autosuggest compatible with preact in IE11. Simply use keyCode in autowhatever in order to avoid IE problems with differently named keys
