### PR TITLE
handle highlightFirstSuggestion state changes

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -123,6 +123,13 @@ export default class Autosuggest extends Component {
 
   // eslint-disable-next-line camelcase, react/sort-comp
   UNSAFE_componentWillReceiveProps(nextProps) {
+    // When highlightFirstSuggestion becomes deactivated, if the first suggestion was
+    // set, we should reset the suggestion back to the unselected default state.
+    const shouldResetHighlighting =
+      this.state.highlightedSuggestionIndex === 0 &&
+      this.props.highlightFirstSuggestion &&
+      !nextProps.highlightFirstSuggestion;
+
     if (shallowEqualArrays(nextProps.suggestions, this.props.suggestions)) {
       if (
         nextProps.highlightFirstSuggestion &&
@@ -131,19 +138,16 @@ export default class Autosuggest extends Component {
         this.justMouseEntered === false
       ) {
         this.highlightFirstSuggestion();
+      } else if (shouldResetHighlighting) {
+        this.resetHighlightedSuggestion();
       }
     } else {
       if (this.willRenderSuggestions(nextProps)) {
         if (this.state.isCollapsed && !this.justSelectedSuggestion) {
           this.revealSuggestions();
-        } else if (!nextProps.highlightFirstSuggestion) {
-          this.resetHighlightedSuggestion();
         }
-        if (
-          this.state.highlightedSuggestionIndex === 0 &&
-          this.props.highlightFirstSuggestion &&
-          !nextProps.highlightFirstSuggestion
-        ) {
+
+        if (shouldResetHighlighting) {
           this.resetHighlightedSuggestion();
         }
       } else {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -137,6 +137,13 @@ export default class Autosuggest extends Component {
         if (this.state.isCollapsed && !this.justSelectedSuggestion) {
           this.revealSuggestions();
         }
+        if (
+          this.state.highlightedSuggestionIndex === 0 &&
+          this.props.highlightFirstSuggestion &&
+          !nextProps.highlightFirstSuggestion
+        ) {
+          this.resetHighlightedSuggestion();
+        }
       } else {
         this.resetHighlightedSuggestion();
       }

--- a/test/focus-first-suggestion/AutosuggestApp.js
+++ b/test/focus-first-suggestion/AutosuggestApp.js
@@ -13,6 +13,12 @@ const getMatchingLanguages = (value) => {
 
 let app = null;
 
+export const getHighlightFirstSuggestion = sinon.spy(
+  (highlightFirstSuggestion, value) => {
+    return Boolean(highlightFirstSuggestion && value);
+  }
+);
+
 export const getSuggestionValue = sinon.spy((suggestion) => {
   return suggestion.name;
 });
@@ -77,7 +83,7 @@ export default class AutosuggestApp extends Component {
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}
-        highlightFirstSuggestion={true}
+        highlightFirstSuggestion={getHighlightFirstSuggestion}
       />
     );
   }

--- a/test/focus-first-suggestion/AutosuggestApp.js
+++ b/test/focus-first-suggestion/AutosuggestApp.js
@@ -4,38 +4,38 @@ import Autosuggest from '../../src/Autosuggest';
 import languages from '../plain-list/languages';
 import { escapeRegexCharacters } from '../../demo/src/components/utils/utils.js';
 
-const getMatchingLanguages = value => {
+const getMatchingLanguages = (value) => {
   const escapedValue = escapeRegexCharacters(value.trim());
   const regex = new RegExp('^' + escapedValue, 'i');
 
-  return languages.filter(language => regex.test(language.name));
+  return languages.filter((language) => regex.test(language.name));
 };
 
 let app = null;
 
-export const getSuggestionValue = sinon.spy(suggestion => {
+export const getSuggestionValue = sinon.spy((suggestion) => {
   return suggestion.name;
 });
 
-export const renderSuggestion = sinon.spy(suggestion => {
+export const renderSuggestion = sinon.spy((suggestion) => {
   return <span>{suggestion.name}</span>;
 });
 
 export const onChange = sinon.spy((event, { newValue }) => {
   app.setState({
-    value: newValue
+    value: newValue,
   });
 });
 
 export const onSuggestionsFetchRequested = sinon.spy(({ value }) => {
   app.setState({
-    suggestions: getMatchingLanguages(value)
+    suggestions: getMatchingLanguages(value),
   });
 });
 
 export const onSuggestionsClearRequested = sinon.spy(() => {
   app.setState({
-    suggestions: []
+    suggestions: [],
   });
 });
 
@@ -43,7 +43,7 @@ export const onSuggestionSelected = sinon.spy();
 
 export const onSuggestionHighlighted = sinon.spy(({ suggestion }) => {
   app.setState({
-    highlightedSuggestion: suggestion
+    highlightedSuggestion: suggestion,
   });
 });
 
@@ -56,7 +56,7 @@ export default class AutosuggestApp extends Component {
     this.state = {
       value: '',
       suggestions: [],
-      highlightedSuggestion: null
+      highlightedSuggestion: null,
     };
   }
 
@@ -64,7 +64,7 @@ export default class AutosuggestApp extends Component {
     const { value, suggestions } = this.state;
     const inputProps = {
       value,
-      onChange
+      onChange,
     };
 
     return (

--- a/test/focus-first-suggestion/AutosuggestApp.js
+++ b/test/focus-first-suggestion/AutosuggestApp.js
@@ -13,11 +13,11 @@ const getMatchingLanguages = (value) => {
 
 let app = null;
 
-export const getHighlightFirstSuggestion = sinon.spy(
-  (highlightFirstSuggestion, value) => {
-    return Boolean(highlightFirstSuggestion && value);
-  }
-);
+export const setHighlightFirstSuggestion = (value) => {
+  app.setState({
+    highlightFirstSuggestion: value
+  });
+};
 
 export const getSuggestionValue = sinon.spy((suggestion) => {
   return suggestion.name;
@@ -63,11 +63,12 @@ export default class AutosuggestApp extends Component {
       value: '',
       suggestions: [],
       highlightedSuggestion: null,
+      highlightFirstSuggestion: false
     };
   }
 
   render() {
-    const { value, suggestions } = this.state;
+    const { value, suggestions, highlightFirstSuggestion } = this.state;
     const inputProps = {
       value,
       onChange,
@@ -83,7 +84,7 @@ export default class AutosuggestApp extends Component {
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}
-        highlightFirstSuggestion={getHighlightFirstSuggestion}
+        highlightFirstSuggestion={highlightFirstSuggestion}
       />
     );
   }

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -21,29 +21,49 @@ import AutosuggestApp, {
   onChange,
   onSuggestionSelected,
   onSuggestionHighlighted,
-  getHighlightFirstSuggestion,
+  setHighlightFirstSuggestion,
 } from './AutosuggestApp';
 
 describe('Autosuggest with highlightFirstSuggestion={true}', () => {
   beforeEach(() => {
     init(TestUtils.renderIntoDocument(<AutosuggestApp />));
+    setHighlightFirstSuggestion(true);
   });
 
   describe('when highlightFirstSuggestion changes from true to false', () => {
-    it('should not have highlighted suggestions', () => {
+    it("should unhighlight the suggestion", () => {
       focusAndSetInputValue('j');
-      getHighlightFirstSuggestion(true, 'j');
       expectHighlightedSuggestion('Java');
-      focusAndSetInputValue('');
-      getHighlightFirstSuggestion(false, '');
+
+      setHighlightFirstSuggestion(false);
       expectHighlightedSuggestion(null);
+    });
+
+    it("should retain the selected suggestion if it was set manually", () => {
+      focusAndSetInputValue('j');
+      expectHighlightedSuggestion('Java');
+      clickDown();
+      expectHighlightedSuggestion('JavaScript');
+
+      setHighlightFirstSuggestion(false);
+      expectHighlightedSuggestion('JavaScript');
+    });
+
+    it("should re-highlight the suggestion if it becomes true again", () => {
+      focusAndSetInputValue('j');
+      expectHighlightedSuggestion('Java');
+
+      setHighlightFirstSuggestion(false);
+      expectHighlightedSuggestion(null);
+
+      setHighlightFirstSuggestion(true);
+      expectHighlightedSuggestion('Java');
     });
   });
 
   describe('when typing and matches exist', () => {
     beforeEach(() => {
       focusAndSetInputValue('j');
-      getHighlightFirstSuggestion(true, 'j');
     });
 
     it('should highlight the first suggestion', () => {

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -15,12 +15,12 @@ import {
   clickEnter,
   clickDown,
   setInputValue,
-  focusAndSetInputValue
+  focusAndSetInputValue,
 } from '../helpers';
 import AutosuggestApp, {
   onChange,
   onSuggestionSelected,
-  onSuggestionHighlighted
+  onSuggestionHighlighted,
 } from './AutosuggestApp';
 
 describe('Autosuggest with highlightFirstSuggestion={true}', () => {
@@ -117,7 +117,7 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
       expect(onChange).to.have.been.calledOnce;
       expect(onChange).to.be.calledWith(syntheticEventMatcher, {
         newValue: 'Perl',
-        method: 'enter'
+        method: 'enter',
       });
     });
   });
@@ -135,7 +135,7 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
           suggestionValue: 'Perl',
           suggestionIndex: 0,
           sectionIndex: null,
-          method: 'enter'
+          method: 'enter',
         }
       );
     });
@@ -147,7 +147,7 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
       focusAndSetInputValue('p');
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'Perl', year: 1987 }
+        suggestion: { name: 'Perl', year: 1987 },
       });
     });
 
@@ -157,7 +157,7 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
       focusAndSetInputValue('c+');
       expect(onSuggestionHighlighted).to.have.been.calledOnce;
       expect(onSuggestionHighlighted).to.have.been.calledWithExactly({
-        suggestion: { name: 'C++', year: 1983 }
+        suggestion: { name: 'C++', year: 1983 },
       });
     });
   });

--- a/test/focus-first-suggestion/AutosuggestApp.test.js
+++ b/test/focus-first-suggestion/AutosuggestApp.test.js
@@ -21,6 +21,7 @@ import AutosuggestApp, {
   onChange,
   onSuggestionSelected,
   onSuggestionHighlighted,
+  getHighlightFirstSuggestion,
 } from './AutosuggestApp';
 
 describe('Autosuggest with highlightFirstSuggestion={true}', () => {
@@ -28,9 +29,21 @@ describe('Autosuggest with highlightFirstSuggestion={true}', () => {
     init(TestUtils.renderIntoDocument(<AutosuggestApp />));
   });
 
+  describe('when highlightFirstSuggestion changes from true to false', () => {
+    it('should not have highlighted suggestions', () => {
+      focusAndSetInputValue('j');
+      getHighlightFirstSuggestion(true, 'j');
+      expectHighlightedSuggestion('Java');
+      focusAndSetInputValue('');
+      getHighlightFirstSuggestion(false, '');
+      expectHighlightedSuggestion(null);
+    });
+  });
+
   describe('when typing and matches exist', () => {
     beforeEach(() => {
       focusAndSetInputValue('j');
+      getHighlightFirstSuggestion(true, 'j');
     });
 
     it('should highlight the first suggestion', () => {


### PR DESCRIPTION
This is to resolve 

> [Bug] highlightedSectionIndex does not reset to null when highlightFirstSuggestion changes from true to false #759

Code was added inside `Autosuggest.js` -> `UNSAFE_componentWillReceiveProps()` to check if `nextProps.highlightFirstSuggestion` had changed. If `nextProps.highlightFirstSuggestion === false` then `this.resetHighlightedSuggestion()` is called. It ensures that nothing is highlighted once `highlightFirstSuggestion` changes from true to false.

A test was added for it under `./focus-first-autosuggestion`. All other tests remain unchanged and continue to pass.