### PR TITLE
Run SpatNav on up/down (in Android TV's WebView)

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -615,6 +615,7 @@ export default class Autosuggest extends Component {
                   reason: 'suggestions-revealed',
                 });
                 this.revealSuggestions();
+                event.preventDefault(); // We act on the key.
               }
             } else if (suggestions.length > 0) {
               const {
@@ -647,7 +648,7 @@ export default class Autosuggest extends Component {
                 newValue,
                 keyCode === 40 ? 'down' : 'up'
               );
-              event.preventDefault(); // Prevents the cursor from moving.
+              event.preventDefault(); // We act on the key.
             }
 
             this.justPressedUpDown = true;

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -647,9 +647,8 @@ export default class Autosuggest extends Component {
                 newValue,
                 keyCode === 40 ? 'down' : 'up'
               );
+              event.preventDefault(); // Prevents the cursor from moving.
             }
-
-            event.preventDefault(); // Prevents the cursor from moving
 
             this.justPressedUpDown = true;
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -170,6 +170,24 @@ export const expectHighlightedSuggestion = suggestion => {
   }
 };
 
+export const saveKeyDown = (event) => {
+  let runBrowserDefault = event.defaultPrevented
+    ? 'defaultPrevented'
+    : 'runBrowserDefault';
+
+  addEvent('onKeyDown-' + runBrowserDefault);
+};
+
+export const expectLetBrowserHandleKeyDown = () => {
+  expect(getEvents()).to.not.deep.include('onKeyDown-defaultPrevented');
+  expect(getEvents()).to.deep.include('onKeyDown-runBrowserDefault');
+};
+
+export const expectDontLetBrowserHandleKeyDown = () => {
+  expect(getEvents()).to.not.deep.include('onKeyDown-runBrowserDefault');
+  expect(getEvents()).to.deep.include('onKeyDown-defaultPrevented');
+};
+
 export const mouseEnterSuggestion = suggestionIndex => {
   Simulate.mouseEnter(getSuggestion(suggestionIndex));
 };

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -5,7 +5,7 @@ import parse from 'autosuggest-highlight/parse';
 import Autosuggest from '../../src/Autosuggest';
 import languages from './languages';
 import { escapeRegexCharacters } from '../../demo/src/components/utils/utils.js';
-import { addEvent } from '../helpers';
+import { addEvent, saveKeyDown } from '../helpers';
 
 const getMatchingLanguages = value => {
   const escapedValue = escapeRegexCharacters(value.trim());
@@ -92,6 +92,7 @@ export default class AutosuggestApp extends Component {
       id: 'my-awesome-autosuggest',
       placeholder: 'Type a programming language',
       type: 'search',
+      onKeyDown: saveKeyDown,
       value,
       onChange,
       onFocus,

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -89,12 +89,12 @@ describe('Default Autosuggest', () => {
       clearEvents();
     });
 
-    it('should let browser handle dpad_down', () => {
+    it('should let browser handle ArrowDown', () => {
       clickDown();
       expectLetBrowserHandleKeyDown();
     });
 
-    it('should let browser handle dpad_up', () => {
+    it('should let browser handle ArrowUp', () => {
       clickUp();
       expectLetBrowserHandleKeyDown();
     });
@@ -173,13 +173,13 @@ describe('Default Autosuggest', () => {
       expectHighlightedSuggestion(null);
     });
 
-    it('should not let browser handle dpad_down', () => {
+    it('should not let browser handle ArrowDown', () => {
       clearEvents();
       clickDown();
       expectDontLetBrowserHandleKeyDown();
     });
 
-    it('should not let browser handle dpad_up', () => {
+    it('should not let browser handle ArrowUp', () => {
       clearEvents();
       clickUp();
       expectDontLetBrowserHandleKeyDown();
@@ -204,13 +204,13 @@ describe('Default Autosuggest', () => {
       expectInputValue('');
     });
 
-    it('should let browser handle dpad_down', () => {
+    it('should let browser handle ArrowDown', () => {
       clearEvents();
       clickDown();
       expectLetBrowserHandleKeyDown();
     });
 
-    it('should let browser handle dpad_down', () => {
+    it('should let browser handle ArrowDown', () => {
       clearEvents();
       clickUp();
       expectLetBrowserHandleKeyDown();
@@ -240,7 +240,7 @@ describe('Default Autosuggest', () => {
       mouseEnterSuggestion(2);
     });
 
-    describe('when pressing down', () => {
+    describe('when pressing ArrowDown', () => {
       beforeEach(() => {
         clickDown();
       });

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -13,6 +13,8 @@ import {
   expectInputReferenceToBeSet,
   expectSuggestions,
   expectHighlightedSuggestion,
+  expectLetBrowserHandleKeyDown,
+  expectDontLetBrowserHandleKeyDown,
   getSuggestionsContainerAttribute,
   mouseEnterSuggestion,
   mouseLeaveSuggestion,
@@ -78,6 +80,23 @@ describe('Default Autosuggest', () => {
 
     it('should set the input reference', () => {
       expectInputReferenceToBeSet();
+    });
+  });
+
+  describe('when input field is focused and empty', () => {
+    beforeEach(() => {
+      focusInput();
+      clearEvents();
+    });
+
+    it('should let browser handle dpad_down', () => {
+      clickDown();
+      expectLetBrowserHandleKeyDown();
+    });
+
+    it('should let browser handle dpad_up', () => {
+      clickUp();
+      expectLetBrowserHandleKeyDown();
     });
   });
 
@@ -153,6 +172,18 @@ describe('Default Autosuggest', () => {
       setInputValue('Per');
       expectHighlightedSuggestion(null);
     });
+
+    it('should not let browser handle dpad_down', () => {
+      clearEvents();
+      clickDown();
+      expectDontLetBrowserHandleKeyDown();
+    });
+
+    it('should not let browser handle dpad_up', () => {
+      clearEvents();
+      clickUp();
+      expectDontLetBrowserHandleKeyDown();
+    });
   });
 
   describe('when typing and matches do not exist', () => {
@@ -171,6 +202,18 @@ describe('Default Autosuggest', () => {
     it('should clear the input when Escape is pressed', () => {
       clickEscape();
       expectInputValue('');
+    });
+
+    it('should let browser handle dpad_down', () => {
+      clearEvents();
+      clickDown();
+      expectLetBrowserHandleKeyDown();
+    });
+
+    it('should let browser handle dpad_down', () => {
+      clearEvents();
+      clickUp();
+      expectLetBrowserHandleKeyDown();
     });
   });
 
@@ -236,8 +279,10 @@ describe('Default Autosuggest', () => {
     });
 
     it('should highlight the first suggestion again', () => {
+      clearEvents();
       clickDown(5);
       expectHighlightedSuggestion('Perl');
+      expectDontLetBrowserHandleKeyDown();
     });
   });
 
@@ -269,8 +314,10 @@ describe('Default Autosuggest', () => {
     });
 
     it('should highlight the last suggestion again', () => {
+      clearEvents();
       clickUp(5);
       expectHighlightedSuggestion('Python');
+      expectDontLetBrowserHandleKeyDown();
     });
   });
 

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -114,7 +114,9 @@ describe('Default Autosuggest', () => {
     });
 
     it('should hide suggestions when Escape is pressed', () => {
+      clearEvents();
       clickEscape();
+      expectDontLetBrowserHandleKeyDown();
       expectSuggestions([]);
     });
 
@@ -256,9 +258,16 @@ describe('Default Autosuggest', () => {
       focusAndSetInputValue('p');
     });
 
-    it('should show suggestions with no highlighted suggestion, if they are hidden', () => {
+    it('should show suggestions with no highlighted suggestion if they were hidden', () => {
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+
+      clearEvents();
       clickEscape();
+      expectDontLetBrowserHandleKeyDown();
+      expectSuggestions([]);
+
       clickDown();
+      expectDontLetBrowserHandleKeyDown();
       expectSuggestions(['Perl', 'PHP', 'Python']);
       expectHighlightedSuggestion(null);
     });
@@ -291,9 +300,16 @@ describe('Default Autosuggest', () => {
       focusAndSetInputValue('p');
     });
 
-    it('should show suggestions with no highlighted suggestion, if they are hidden', () => {
+    it('should show suggestions with no highlighted suggestion if they were hidden', () => {
+      expectSuggestions(['Perl', 'PHP', 'Python']);
+
+      clearEvents();
       clickEscape();
+      expectDontLetBrowserHandleKeyDown();
+      expectSuggestions([]);
+
       clickUp();
+      expectDontLetBrowserHandleKeyDown();
       expectSuggestions(['Perl', 'PHP', 'Python']);
       expectHighlightedSuggestion(null);
     });


### PR DESCRIPTION
 Run SpatNav on up/down (in Android TV's WebView)

Background:
Spatial Navigation is Chromium's DPAD-mechanics
that runs in Android WebView on Android TV and
if you run Chrome with --enable-spatial-navigation.
SpatNav runs as Chrome's default action on keydown.

Problem:
Once focus goes to a search box, DPAD_UP/DOWN
in Android TV's WebViews can not move focus
outside the search box. Focus gets trapped.

This happens because react-autosuggest *always*
prevents the default action (Spatial Navigation
in Android TV's WebViews).

Solution:
Do not prevent Spatial Navigation from running
when no suggestions are shown.

Testing done:
1) npm start
2) Quit Chrome.
3) chrome --enable-spatial-navigation
     http://localhost:3000/demo/dist/index.html
4) Ensure that the arrow keys can move between
   all fields and links.