### PR TITLE
Add a reason parameter to shouldRenderSuggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,15 +406,25 @@ where:
 
 By default, suggestions are rendered when the input isn't blank. Feel free to override this behaviour.
 
-This function gets the current value of the input, and it should return a boolean.
+This function gets the current value of the input and the reason why the suggestions might be rendered, and it should return a boolean.
 
 For example, to display suggestions only when input value is at least 3 characters long, do:
 
 ```js
-function shouldRenderSuggestions(value) {
+function shouldRenderSuggestions(value, reason) {
   return value.trim().length > 2;
 }
 ```
+
+You can use the second `reason` argument to finely control exactly when the suggestions are rendered. The possible values are closely related to those for `onSuggestionsFetchRequested`, plus a few extra cases:
+
+- `'input-changed'` - user typed something
+- `'input-focused'` - input was focused
+- `'input-blurred'` - input was un-focused
+- `'escape-pressed'` - user pressed <kbd>Escape</kbd> to clear the input (and suggestions are shown for empty input)
+- `'suggestions-revealed'` - user pressed <kbd>Up</kbd> or <kbd>Down</kbd> to reveal suggestions
+- `'suggestions-updated'` - the suggestions were updated
+- `'render'` - the component is re-rendering
 
 When `shouldRenderSuggestions` returns `true`, **suggestions will be rendered only when the input is focused**.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "mkdir -p demo/dist && npm run copy-static-files && node server",
     "prettier": "prettier --single-quote --write",
+    "prettier:src": "npm run prettier -- \"src/**/*.js\"",
     "prettier:all": "npm run prettier -- \".*.js\" \"*.js\" \"demo/src/**/*.js\" \"demo/standalone/app.js\" \"src/**/*.js\" \"test/**/*.js\"",
     "lint": "eslint src test demo/src demo/standalone/app.js server.js webpack.*.js",
     "test": "cross-env NODE_ENV=test nyc mocha \"test/**/*.test.js\"",
@@ -18,7 +19,7 @@
     "dist": "rm -rf dist && mkdir dist && babel src -d dist",
     "demo-dist": "rm -rf demo/dist && mkdir demo/dist && npm run copy-static-files && cross-env BABEL_ENV=production webpack --config webpack.gh-pages.config.js",
     "standalone": "cross-env BABEL_ENV=production webpack --config webpack.standalone.config.js && webpack --config webpack.standalone-demo.config.js",
-    "prebuild": "npm run prettier && npm run lint && npm test",
+    "prebuild": "npm run prettier:src && npm run lint && npm test",
     "build": "npm run dist && npm run standalone",
     "gh-pages-build": "npm run prebuild && npm run demo-dist",
     "postversion": "git push && git push --tags",
@@ -93,7 +94,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run prettier"
+      "npm run prettier:src"
     ]
   },
   "keywords": [

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -133,7 +133,7 @@ export default class Autosuggest extends Component {
         this.highlightFirstSuggestion();
       }
     } else {
-      if (this.willRenderSuggestions(nextProps)) {
+      if (this.willRenderSuggestions(nextProps, 'suggestions-updated')) {
         if (this.state.isCollapsed && !this.justSelectedSuggestion) {
           this.revealSuggestions();
         }
@@ -328,11 +328,11 @@ export default class Autosuggest extends Component {
     }
   }
 
-  willRenderSuggestions(props) {
+  willRenderSuggestions(props, reason) {
     const { suggestions, inputProps, shouldRenderSuggestions } = props;
     const { value } = inputProps;
 
-    return suggestions.length > 0 && shouldRenderSuggestions(value);
+    return suggestions.length > 0 && shouldRenderSuggestions(value, reason);
   }
 
   storeAutowhateverRef = (autowhatever) => {
@@ -440,7 +440,7 @@ export default class Autosuggest extends Component {
     const { inputProps, shouldRenderSuggestions } = this.props;
     const { value, onBlur } = inputProps;
     const highlightedSuggestion = this.getHighlightedSuggestion();
-    const shouldRender = shouldRenderSuggestions(value);
+    const shouldRender = shouldRenderSuggestions(value, 'input-blurred');
 
     this.setState({
       isFocused: false,
@@ -535,7 +535,7 @@ export default class Autosuggest extends Component {
       ? alwaysTrue
       : this.props.shouldRenderSuggestions;
     const { value, onFocus, onKeyDown } = inputProps;
-    const willRenderSuggestions = this.willRenderSuggestions(this.props);
+    const willRenderSuggestions = this.willRenderSuggestions(this.props, 'render');
     const isOpen =
       alwaysRenderSuggestions ||
       (isFocused && !isCollapsed && willRenderSuggestions);
@@ -547,7 +547,7 @@ export default class Autosuggest extends Component {
           !this.justSelectedSuggestion &&
           !this.justClickedOnSuggestionsContainer
         ) {
-          const shouldRender = shouldRenderSuggestions(value);
+          const shouldRender = shouldRenderSuggestions(value, 'input-focused');
 
           this.setState({
             isFocused: true,
@@ -576,7 +576,7 @@ export default class Autosuggest extends Component {
       },
       onChange: (event) => {
         const { value } = event.target;
-        const shouldRender = shouldRenderSuggestions(value);
+        const shouldRender = shouldRenderSuggestions(value, 'input-changed');
 
         this.maybeCallOnChange(event, value, 'type');
 
@@ -609,7 +609,7 @@ export default class Autosuggest extends Component {
           case 40: // ArrowDown
           case 38: // ArrowUp
             if (isCollapsed) {
-              if (shouldRenderSuggestions(value)) {
+              if (shouldRenderSuggestions(value, 'suggestions-revealed')) {
                 onSuggestionsFetchRequested({
                   value,
                   reason: 'suggestions-revealed',
@@ -714,7 +714,7 @@ export default class Autosuggest extends Component {
 
                 this.maybeCallOnChange(event, newValue, 'escape');
 
-                if (shouldRenderSuggestions(newValue)) {
+                if (shouldRenderSuggestions(newValue, 'escape-pressed')) {
                   onSuggestionsFetchRequested({
                     value: newValue,
                     reason: 'escape-pressed',

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -10,6 +10,14 @@ const defaultRenderSuggestionsContainer = ({ containerProps, children }) => (
   <div {...containerProps}>{children}</div>
 );
 
+const REASON_SUGGESTIONS_REVEALED = 'suggestions-revealed';
+const REASON_SUGGESTIONS_UPDATED = 'suggestions-updated';
+const REASON_SUGGESTION_SELECTED = 'suggestion-selected';
+const REASON_INPUT_FOCUSED = 'input-focused';
+const REASON_INPUT_CHANGED = 'input-changed';
+const REASON_INPUT_BLURRED = 'input-blurred';
+const REASON_ESCAPE_PRESSED = 'escape-pressed';
+
 export default class Autosuggest extends Component {
   static propTypes = {
     suggestions: PropTypes.array.isRequired,
@@ -133,7 +141,7 @@ export default class Autosuggest extends Component {
         this.highlightFirstSuggestion();
       }
     } else {
-      if (this.willRenderSuggestions(nextProps, 'suggestions-updated')) {
+      if (this.willRenderSuggestions(nextProps, REASON_SUGGESTIONS_UPDATED)) {
         if (this.state.isCollapsed && !this.justSelectedSuggestion) {
           this.revealSuggestions();
         }
@@ -393,7 +401,7 @@ export default class Autosuggest extends Component {
     if (alwaysRenderSuggestions) {
       onSuggestionsFetchRequested({
         value: data.suggestionValue,
-        reason: 'suggestion-selected',
+        reason: REASON_SUGGESTION_SELECTED,
       });
     } else {
       this.onSuggestionsClearRequested();
@@ -440,7 +448,7 @@ export default class Autosuggest extends Component {
     const { inputProps, shouldRenderSuggestions } = this.props;
     const { value, onBlur } = inputProps;
     const highlightedSuggestion = this.getHighlightedSuggestion();
-    const shouldRender = shouldRenderSuggestions(value, 'input-blurred');
+    const shouldRender = shouldRenderSuggestions(value, REASON_INPUT_BLURRED);
 
     this.setState({
       isFocused: false,
@@ -550,7 +558,10 @@ export default class Autosuggest extends Component {
           !this.justSelectedSuggestion &&
           !this.justClickedOnSuggestionsContainer
         ) {
-          const shouldRender = shouldRenderSuggestions(value, 'input-focused');
+          const shouldRender = shouldRenderSuggestions(
+            value,
+            REASON_INPUT_FOCUSED
+          );
 
           this.setState({
             isFocused: true,
@@ -560,7 +571,10 @@ export default class Autosuggest extends Component {
           onFocus && onFocus(event);
 
           if (shouldRender) {
-            onSuggestionsFetchRequested({ value, reason: 'input-focused' });
+            onSuggestionsFetchRequested({
+              value,
+              reason: REASON_INPUT_FOCUSED,
+            });
           }
         }
       },
@@ -579,7 +593,10 @@ export default class Autosuggest extends Component {
       },
       onChange: (event) => {
         const { value } = event.target;
-        const shouldRender = shouldRenderSuggestions(value, 'input-changed');
+        const shouldRender = shouldRenderSuggestions(
+          value,
+          REASON_INPUT_CHANGED
+        );
 
         this.maybeCallOnChange(event, value, 'type');
 
@@ -600,7 +617,7 @@ export default class Autosuggest extends Component {
         });
 
         if (shouldRender) {
-          onSuggestionsFetchRequested({ value, reason: 'input-changed' });
+          onSuggestionsFetchRequested({ value, reason: REASON_INPUT_CHANGED });
         } else {
           this.onSuggestionsClearRequested();
         }
@@ -612,10 +629,10 @@ export default class Autosuggest extends Component {
           case 40: // ArrowDown
           case 38: // ArrowUp
             if (isCollapsed) {
-              if (shouldRenderSuggestions(value, 'suggestions-revealed')) {
+              if (shouldRenderSuggestions(value, REASON_SUGGESTIONS_REVEALED)) {
                 onSuggestionsFetchRequested({
                   value,
-                  reason: 'suggestions-revealed',
+                  reason: REASON_SUGGESTIONS_REVEALED,
                 });
                 this.revealSuggestions();
               }
@@ -717,10 +734,10 @@ export default class Autosuggest extends Component {
 
                 this.maybeCallOnChange(event, newValue, 'escape');
 
-                if (shouldRenderSuggestions(newValue, 'escape-pressed')) {
+                if (shouldRenderSuggestions(newValue, REASON_ESCAPE_PRESSED)) {
                   onSuggestionsFetchRequested({
                     value: newValue,
-                    reason: 'escape-pressed',
+                    reason: REASON_ESCAPE_PRESSED,
                   });
                 } else {
                   this.onSuggestionsClearRequested();

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -535,7 +535,10 @@ export default class Autosuggest extends Component {
       ? alwaysTrue
       : this.props.shouldRenderSuggestions;
     const { value, onFocus, onKeyDown } = inputProps;
-    const willRenderSuggestions = this.willRenderSuggestions(this.props, 'render');
+    const willRenderSuggestions = this.willRenderSuggestions(
+      this.props,
+      'render'
+    );
     const isOpen =
       alwaysRenderSuggestions ||
       (isFocused && !isCollapsed && willRenderSuggestions);

--- a/src/theme.js
+++ b/src/theme.js
@@ -12,10 +12,10 @@ export const defaultTheme = {
   suggestionHighlighted: 'react-autosuggest__suggestion--highlighted',
   sectionContainer: 'react-autosuggest__section-container',
   sectionContainerFirst: 'react-autosuggest__section-container--first',
-  sectionTitle: 'react-autosuggest__section-title'
+  sectionTitle: 'react-autosuggest__section-title',
 };
 
-export const mapToAutowhateverTheme = theme => {
+export const mapToAutowhateverTheme = (theme) => {
   let result = {};
 
   for (const key in theme) {

--- a/test/plain-list/AutosuggestApp.js
+++ b/test/plain-list/AutosuggestApp.js
@@ -44,9 +44,10 @@ export const onChange = sinon.spy((event, { newValue }) => {
 export const onFocus = sinon.spy();
 export const onBlur = sinon.spy();
 
-export const shouldRenderSuggestions = sinon.spy(value => {
+export const defaultShouldRenderSuggestionsStub = (value) => {
   return value.trim().length > 0 && value[0] !== ' ';
-});
+};
+export const shouldRenderSuggestions = sinon.stub().callsFake(defaultShouldRenderSuggestionsStub);
 
 export const onSuggestionsFetchRequested = sinon.spy(({ value }) => {
   app.setState({

--- a/test/plain-list/AutosuggestApp.test.js
+++ b/test/plain-list/AutosuggestApp.test.js
@@ -580,7 +580,11 @@ describe('Default Autosuggest', () => {
 
     it('should be called with the right parameters', () => {
       focusAndSetInputValue('e');
-      expect(shouldRenderSuggestions).to.be.calledWithExactly('e');
+      expect(shouldRenderSuggestions.callCount).to.equal(4);
+      expect(shouldRenderSuggestions.getCall(0).args).to.deep.equal(['', 'input-focused']);
+      expect(shouldRenderSuggestions.getCall(1).args).to.deep.equal(['e', 'input-changed']);
+      expect(shouldRenderSuggestions.getCall(2).args).to.deep.equal(['e', 'suggestions-updated']);
+      expect(shouldRenderSuggestions.getCall(3).args).to.deep.equal(['e', 'render']);
     });
 
     it('should show suggestions when true is returned', () => {


### PR DESCRIPTION
This pull request:

* Fixes #772, as described in that issue.
* Fixes `npm run build`, by fixing prettier to run against `src`.
  This wasn't working because `npm run prettier` is missing an argument for which files to prettify. Rather than following #763 and running `prettier:all` (and reformatting a huge amount of code) this just prettifies the src files, which appear to be the previous prettier'd content, and are already very close to correct anyway. If this is merged, #763 could be closed too.