### PR TITLE
Fix _this.input.focus() is undefined issue on mobile

### DIFF
--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -509,7 +509,9 @@ export default class Autosuggest extends Component {
   onSuggestionTouchMove = () => {
     this.justSelectedSuggestion = false;
     this.pressedSuggestion = null;
-    this.input.focus();
+    if (this.input.focus) {
+      this.input.focus();
+    }
   };
 
   itemProps = ({ sectionIndex, itemIndex }) => {


### PR DESCRIPTION
On mobile browsers I've seen this problem in our error logs quite often:

```
TypeError: l.input.focus is not a function
1
File "webpack:///./node_modules/react-autosuggest/dist/Autosuggest.js" line 249 col 19 in Autosuggest
_this.input.focus();
```

It's very similar to what has been mentioned in these issues:
https://github.com/moroshko/react-autosuggest/issues/646
https://github.com/moroshko/react-autosuggest/issues/669

I simply wrapped the focus function so that we make sure it is defined before trying to call the function.

We were able to reproduce the bug consistently by scrolling on the dropdown component in a mobile browser or iOS Simulator.

Hope this helps!