### PR TITLE
Remove unexpected listbox role from autowhatever items container. Fix #701

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -419,7 +419,6 @@ export default class Autowhatever extends Component {
     const itemsContainer = renderItemsContainer({
       containerProps: {
         id: itemsContainerId,
-        role: 'listbox',
         ...theme(
           `react-autowhatever-${id}-items-container`,
           'itemsContainer',


### PR DESCRIPTION
This fixes #701. Currently this can be done per-project with `renderSuggestionsContainer`, but there is no reason for this container to have a `listbox` role to start with since the list within already does.

Once this is fixed, I believe #770 will be the only bug preventing this project from really following WAI-ARIA combobox markup to the letter.